### PR TITLE
fix: improve perf of count with smarter handling of half-open range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rust-lapper"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "bincode",
  "cpu-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-lapper"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Seth Stadick <sstadick@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
The BITS paper uses fully inclusive ranges. When this was written I'm not sure I understood that. To get things to match the naive version of count (find -> count) I had a while loop in the bits count method to advance the cursor past the matched start/stop index.

This change was found while porting mojo-lapper and removes the while loop. It also has a more effecient branchless binary search.

Benchmarks for count improve 24-30% (see PR).


```bash
Bakeoff/rust-lapper: count with 100% hit rate                                                                             
                        time:   [14.742 us 14.773 us 14.811 us]
                        change: [-24.448% -24.164% -23.869%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  18 (18.00%) high severe
Bakeoff/rust-lapper: count with below 100% hit rate                                                                             
                        time:   [2.1958 us 2.2019 us 2.2076 us]
                        change: [-30.391% -29.790% -29.274%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) low mild                                                                                                                                              
Benchmarking Bakeoff/rust-lapper: count with below 100% hit rate - chromosome spanning interval: Collecting 100 samples in estimated 5.0080 s (2.3M ite                                                                                                                                                       Bakeoff/rust-lapper: count with below 100% hit rate - chromosome spanning interval                        
                        time:   [2.1989 us 2.2070 us 2.2148 us]
                        change: [-32.616% -30.807% -29.536%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) low mild
  1 (1.00%) high severe
```