### PR TITLE
perf(alloc): feature for sort_unstable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install pinned toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.95.0
           override: true
 
       - name: Cache dependencies
@@ -36,11 +36,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install pinned toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.95.0
           override: true
           components: rustfmt, clippy
 
@@ -69,11 +69,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install pinned toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.95.0
           override: true
 
       - name: Cache dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rust-lapper"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "bincode",
  "cpu-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ name = "ex1"
 [features]
 default = []
 with_serde = ["serde/derive"]
+sort_unstable = []
 
 [dependencies]
 num-traits = "0.2.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-lapper"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Seth Stadick <sstadick@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ fn main() {
 
 ## Release Notes
 
+- `1.3.0`: Add the `sort_unstable` feature flag for allocation-sensitive sorting.
 - `1.1.0`: Added insert functionality thanks to @zaporter
 - `0.4.0`: Addition of the BITS count algorithm.
 - `0.4.2`: Bugfix in to update starts/stops vectors when overlaps merged

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ fn main() {
 
 ## Release Notes
 
-- `1.3.0`: Add the `sort_unstable` feature flag for allocation-sensitive sorting.
+- `1.3.0`: Add the `sort_unstable` feature flag for allocation-sensitive sorting thanks to @jameslkingsley.
 - `1.1.0`: Added insert functionality thanks to @zaporter
 - `0.4.0`: Addition of the BITS count algorithm.
 - `0.4.2`: Bugfix in to update starts/stops vectors when overlaps merged

--- a/benches/lapper_benchmark.rs
+++ b/benches/lapper_benchmark.rs
@@ -3,14 +3,12 @@ extern crate criterion;
 extern crate rand;
 extern crate rust_lapper;
 
-use cpu_time::ProcessTime;
 use criterion::black_box;
-use criterion::Criterion;
-use rand::prelude::*;
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
+use rand::rngs::StdRng;
 use rand::Rng;
+use rand::SeedableRng;
 use rust_lapper::{Interval, Lapper};
-use std::ops::Range;
-use std::time::Duration;
 
 type Iv = Interval<u32, bool>;
 
@@ -21,7 +19,7 @@ fn randomi(imin: u32, imax: u32) -> u32 {
 
 fn make_random(n: usize, range_max: u32, size_min: u32, size_max: u32) -> Vec<Iv> {
     let mut result = Vec::with_capacity(n);
-    for i in 0..n {
+    for _ in 0..n {
         let s = randomi(0, range_max);
         let e = s + randomi(size_min, size_max);
         result.push(Interval {
@@ -42,6 +40,41 @@ fn make_interval_set() -> (Vec<Iv>, Vec<Iv>) {
     let intervals = make_random(n, chrom_size, min_interval_size, max_interval_size);
     let other_intervals = make_random(n, 10 * chrom_size, 1, 2);
     (intervals, other_intervals)
+}
+
+fn make_random_seeded(
+    n: usize,
+    range_max: u32,
+    size_min: u32,
+    size_max: u32,
+    seed: u64,
+) -> Vec<Iv> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut result = Vec::with_capacity(n);
+    for _ in 0..n {
+        let s = rng.gen_range(0, range_max);
+        let e = s + rng.gen_range(size_min, size_max);
+        result.push(Interval {
+            start: s,
+            stop: e,
+            val: false,
+        });
+    }
+    result
+}
+
+fn make_non_overlapping(n: usize) -> Vec<Iv> {
+    (0..n)
+        .rev()
+        .map(|i| {
+            let start = (i as u32) * 10;
+            Interval {
+                start,
+                stop: start + 5,
+                val: false,
+            }
+        })
+        .collect()
 }
 
 pub fn query(c: &mut Criterion) {
@@ -145,5 +178,53 @@ pub fn query(c: &mut Criterion) {
     comparison_group.finish();
 }
 
-criterion_group!(benches, query);
+pub fn construction(c: &mut Criterion) {
+    let sizes = [1_000usize, 10_000, 100_000];
+    let chrom_size = 100_000_000;
+    let min_interval_size = 500;
+    let max_interval_size = 80000;
+
+    let mut construction_group = c.benchmark_group("Construction");
+    for &n in sizes.iter() {
+        construction_group.throughput(Throughput::Elements(n as u64));
+        let intervals = make_random_seeded(
+            n,
+            chrom_size,
+            min_interval_size,
+            max_interval_size,
+            n as u64,
+        );
+        let non_overlapping_intervals = make_non_overlapping(n);
+
+        construction_group.bench_with_input(
+            BenchmarkId::new("Lapper::new from unsorted intervals", n),
+            &intervals,
+            |b, intervals| {
+                b.iter_batched(
+                    || intervals.clone(),
+                    |intervals| black_box(Lapper::new(black_box(intervals))),
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+
+        construction_group.bench_with_input(
+            BenchmarkId::new("merge_overlaps non-overlapping intervals", n),
+            &non_overlapping_intervals,
+            |b, intervals| {
+                b.iter_batched(
+                    || Lapper::new(intervals.clone()),
+                    |mut lapper| {
+                        lapper.merge_overlaps();
+                        black_box(lapper)
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    construction_group.finish();
+}
+
+criterion_group!(benches, query, construction);
 criterion_main!(benches);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1384,6 +1384,7 @@ mod tests {
         assert_eq!(lapper.count(28974798, 33141355), 1);
     }
 
+    #[cfg(feature = "with_serde")]
     #[test]
     fn serde_test() {
         let data = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,11 +194,27 @@ where
     /// let lapper = Lapper::new(data);
     /// ```
     pub fn new(mut intervals: Vec<Interval<I, T>>) -> Self {
+        #[cfg(feature = "sort_unstable")]
+        intervals.sort_unstable();
+
+        #[cfg(not(feature = "sort_unstable"))]
         intervals.sort();
+
         let (mut starts, mut stops): (Vec<_>, Vec<_>) =
             intervals.iter().map(|x| (x.start, x.stop)).unzip();
-        starts.sort();
-        stops.sort();
+
+        #[cfg(feature = "sort_unstable")]
+        {
+            starts.sort_unstable();
+            stops.sort_unstable();
+        }
+
+        #[cfg(not(feature = "sort_unstable"))]
+        {
+            starts.sort();
+            stops.sort();
+        }
+
         let mut max_len = zero::<I>();
         for interval in intervals.iter() {
             let i_len = interval
@@ -376,8 +392,19 @@ where
         // Fix the starts and stops used by counts
         let (mut starts, mut stops): (Vec<_>, Vec<_>) =
             self.intervals.iter().map(|x| (x.start, x.stop)).unzip();
-        starts.sort();
-        stops.sort();
+
+        #[cfg(feature = "sort_unstable")]
+        {
+            starts.sort_unstable();
+            stops.sort_unstable();
+        }
+
+        #[cfg(not(feature = "sort_unstable"))]
+        {
+            starts.sort();
+            stops.sort();
+        }
+
         self.starts = starts;
         self.stops = stops;
         self.max_len = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@ where
 
     /// Return an iterator over the intervals in Lapper
     #[inline]
-    pub fn iter(&self) -> IterLapper<I, T> {
+    pub fn iter(&self) -> IterLapper<'_, I, T> {
         IterLapper {
             inner: self,
             pos: 0,
@@ -574,7 +574,7 @@ where
     ///             Interval { start: 20, stop: 25, val: 1 }]);
     /// ```
     #[inline]
-    pub fn depth(&self) -> IterDepth<I, T> {
+    pub fn depth(&self) -> IterDepth<'_, I, T> {
         let mut merged_lapper = Lapper::new(
             self.intervals
                 .iter()
@@ -626,7 +626,7 @@ where
     /// assert_eq!(lapper.find(5, 11).count(), 2);
     /// ```
     #[inline]
-    pub fn find(&self, start: I, stop: I) -> IterFind<I, T> {
+    pub fn find(&self, start: I, stop: I) -> IterFind<'_, I, T> {
         IterFind {
             inner: self,
             off: Self::lower_bound(


### PR DESCRIPTION
- Adds a feature flag for using `sort_unstable` instead of `sort`
- Uses conditional compilation instead of `cfg!` to avoid adding branches
- `sort_unstable` reduces allocations but can be slower if the `Vec` is already partially sorted