### PR TITLE
Add a portable SIMD block index for forward overlap queries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,30 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  msrv:
+    name: MSRV 1.59
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install MSRV toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.59.0
+          override: true
+          target: aarch64-unknown-linux-gnu
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Test on the MSRV
+        run: cargo test --all-features --locked
+
+      - name: Check AArch64 NEON on the MSRV
+        run: cargo check --lib --all-features --locked --target aarch64-unknown-linux-gnu
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,33 @@ jobs:
           command: clippy
           args: --all-features -- -D warnings
 
+  native-avx2:
+    name: Native AVX2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install pinned toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.95.0
+          override: true
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Record and require AVX2
+        run: |
+          lscpu
+          grep -qw avx2 /proc/cpuinfo
+
+      - name: Exercise runtime dispatch and AVX2 masks
+        run: |
+          cargo test --all-features simd::dispatch_tests::selected_backend_matches_the_host -- --exact --nocapture
+          cargo test --all-features simd::avx2::tests::primitive_masks_match_scalar_when_avx2_is_available -- --exact --nocapture
+
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,11 +7,14 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTUP_TOOLCHAIN: stable
 
 jobs:
   msrv:
     name: MSRV 1.59
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.59.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
@@ -37,11 +40,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install pinned toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.95.0
+          toolchain: stable
           override: true
 
       - name: Cache dependencies
@@ -51,7 +54,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all-features
+          args: --all-targets --all-features --locked
 
   lints:
     name: Lints
@@ -60,11 +63,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install pinned toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.95.0
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 
@@ -81,7 +84,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features -- -D warnings
+          args: --all-targets --all-features --locked -- -D warnings
 
   native-avx2:
     name: Native AVX2
@@ -90,11 +93,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install pinned toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.95.0
+          toolchain: stable
           override: true
 
       - name: Cache dependencies
@@ -107,28 +110,108 @@ jobs:
 
       - name: Exercise runtime dispatch and AVX2 masks
         run: |
-          cargo test --all-features simd::dispatch_tests::selected_backend_matches_the_host -- --exact --nocapture
-          cargo test --all-features simd::avx2::tests::primitive_masks_match_scalar_when_avx2_is_available -- --exact --nocapture
+          cargo test --all-features --locked simd::dispatch_tests::selected_backend_matches_the_host -- --exact --nocapture
+          cargo test --all-features --locked simd::avx2::tests::primitive_masks_match_scalar_when_avx2_is_available -- --exact --nocapture
 
-  test:
-    name: Test Suite
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+  scalar-x86:
+    name: Scalar x86-64
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install pinned toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.95.0
+          toolchain: stable
+          override: true
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes qemu-user
+          qemu-x86_64 --version
+
+      - name: Exercise scalar runtime dispatch without AVX2
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: qemu-x86_64 -cpu Nehalem
+        run: |
+          cargo test --all-features --locked --target x86_64-unknown-linux-gnu simd::dispatch_tests::selected_backend_matches_the_host -- --exact --nocapture
+          cargo test --all-features --locked --target x86_64-unknown-linux-gnu
+
+  scalar-targets:
+    name: Scalar fallback targets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: i686-unknown-linux-gnu, powerpc64le-unknown-linux-gnu, wasm32-unknown-unknown
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1
+
+      - name: Check scalar-only architectures
+        run: |
+          cargo check --lib --all-features --locked --target i686-unknown-linux-gnu
+          cargo check --lib --all-features --locked --target powerpc64le-unknown-linux-gnu
+          cargo check --lib --all-features --locked --target wasm32-unknown-unknown
+
+  test:
+    name: Test Suite (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Linux, default features
+            os: ubuntu-latest
+            features: ""
+          - name: Linux, serde
+            os: ubuntu-latest
+            features: --features with_serde
+          - name: Linux, unstable sort
+            os: ubuntu-latest
+            features: --features sort_unstable
+          - name: Linux, all features
+            os: ubuntu-latest
+            features: --all-features
+          - name: macOS ARM64, all features
+            os: macos-15
+            features: --all-features
+            neon: true
+          - name: Windows, all features
+            os: windows-latest
+            features: --all-features
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
           override: true
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
 
       - name: Run tests
-        run: cargo test --verbose --all-features
+        run: cargo test --verbose --locked ${{ matrix.features }}
+
+      - name: Verify native NEON dispatch
+        if: matrix.neon
+        run: |
+          test "$(uname -m)" = arm64
+          cargo test --all-features --locked simd::dispatch_tests::selected_backend_matches_the_host -- --exact --nocapture
+          cargo test --all-features --locked --test portable_index every_primitive_integer_type_matches_forward_brute_force -- --exact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,18 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install MSRV toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.59.0
         with:
-          profile: minimal
-          toolchain: 1.59.0
-          override: true
-          target: aarch64-unknown-linux-gnu
+          targets: aarch64-unknown-linux-gnu
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Test on the MSRV
         run: cargo test --all-features --locked
@@ -38,70 +35,50 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets --all-features --locked
+        run: cargo check --all-targets --all-features --locked
 
   lints:
     name: Lints
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+          components: rustfmt,clippy
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features --locked -- -D warnings
+        run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
   native-avx2:
     name: Native AVX2
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Record and require AVX2
         run: |
@@ -118,17 +95,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Install QEMU
         run: |
@@ -148,18 +121,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          target: i686-unknown-linux-gnu, powerpc64le-unknown-linux-gnu, wasm32-unknown-unknown
+          targets: i686-unknown-linux-gnu,powerpc64le-unknown-linux-gnu,wasm32-unknown-unknown
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Check scalar-only architectures
         run: |
@@ -194,17 +164,13 @@ jobs:
             features: --all-features
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test --verbose --locked ${{ matrix.features }}

--- a/AARCH64_U32_HAND_TYPE.md
+++ b/AARCH64_U32_HAND_TYPE.md
@@ -1,97 +1,579 @@
-# Hand-type the AArch64 `u32` mask path
+# Hand-type the whole forward index: original Lapper to portable SIMD
 
-This is a deliberately narrow exercise: add the forward-order AArch64 NEON mask
-to the preserved 32-block rust-lapper prototype. The answer branch avoids generic
-type dispatch, x86, mutation rebuilding, and unchecked indexing so each machine-
-level idea is visible once.
+This is the single end-to-end exercise for understanding the worked
+rust-lapper contender. It starts with the original start-sorted linear iterator,
+adds the first per-interval skip index, replaces it with the 32-entry block
+index, adds exact block routes and a saved scalar mask, types the AArch64 NEON
+path one operation at a time, and finishes with the portable, mutation-safe
+implementation.
 
-## Set up the exercise
+Do not begin with the SIMD intrinsics. SIMD is only a faster implementation of
+one integer-valued function. The data structure, skip proofs, iterator state,
+and output order must already make sense before that function is replaced.
 
-Create your own branch from the exact 32-block source:
+Every checkpoint has the same four gates:
+
+1. **Type it:** the smallest useful source change.
+2. **State the invariant:** the fact that makes the change correct.
+3. **Work an example:** calculate the result without running Rust.
+4. **Pass the gate:** compare with a preserved branch and run an exact-order test.
+
+## Set up a practice worktree
+
+Keep this worked branch open as the guide and create a second worktree from the
+original release state:
 
 ```bash
-git switch contender/block-32
-git switch -c practice/aarch64-u32-mask
+cd /Users/sethstadick/dev/super_intervals_more/bakeoff/sandboxes/rust-lapper-contenders
+
+git worktree add \
+  -b practice/hand-typed-forward-index \
+  ../rust-lapper-hand-typed \
+  baseline/v1.3.0
+
+cd ../rust-lapper-hand-typed
 ```
 
-Use the tutorial branch only as the answer key:
+The preserved answer checkpoints are:
+
+| Checkpoint | Branch | What it isolates |
+|---|---|---|
+| Original | `baseline/v1.3.0` | Start-sorted scalar Lapper |
+| First index | `contender/per-interval` | One next-greater-end link per interval |
+| Block index | `contender/block-32` | One summary and link per 32 intervals |
+| First mask | `contender/simd-mask` | Exact routes, saved mask, first NEON implementation |
+| Weighted mask | `contender/simd-mask-addv` | Four truth lanes reduced to four bits |
+| Paired loads | `contender/simd-mask-addv-ld1x2` | Eight values loaded per loop |
+| Eight-lane pack | `contender/simd-mask-narrow8-ld1x2` | Eight truths reduced once |
+| Bounds audit | `contender/simd-mask-narrow8-unchecked-index` | Proof-scoped unchecked sidecars |
+| Narrow ARM answer | `tutorial/aarch64-u32-hand-typed` | The ARM-only portion without portable integration |
+| Full answer | `worked/portable-simd-index` | Normal API, all primitive types, mutation, serde, and fallbacks |
+
+Use this as the progress sheet:
+
+- [ ] 0. Install the forward brute-force oracle.
+- [ ] 1. Explain original `max_len` search and its pathological case.
+- [ ] 2. Build and prove per-interval next-greater links.
+- [ ] 3. Replace them with 32-entry block summaries and links.
+- [ ] 4. Binary-search block prefix maxima.
+- [ ] 5. Derive the exact skip, dense, and mixed routes.
+- [ ] 6. Save and drain a scalar block mask.
+- [ ] 7. Reproduce that mask with four-lane NEON comparisons.
+- [ ] 8. Pack four truth lanes with weighted horizontal addition.
+- [ ] 9. Pair loads, narrow truth, and pack eight lanes once.
+- [ ] 10. Find the intended instructions in release assembly.
+- [ ] 11. Move the mask state behind normal `find()` and `seek()`.
+- [ ] 12. Add exact type and CPU dispatch with scalar fallback.
+- [ ] 13. Rebuild all derived state after mutation and deserialize.
+- [ ] 14. Repair the scalar algorithms for signed coordinates.
+- [ ] 15. Remove only bounds checks covered by private invariants.
+
+At any point, inspect the historical delta rather than copying the whole file:
 
 ```bash
-git diff tutorial/aarch64-u32-hand-typed -- src/lib.rs tests/block_index.rs
+git diff baseline/v1.3.0..contender/per-interval -- src/lib.rs
+git diff contender/per-interval..contender/block-32 -- src/lib.rs
+git diff contender/block-32..contender/simd-mask -- src/lib.rs tests/block_index.rs
 ```
 
-Run this checkpoint after every stage:
+The historical index and SIMD branches through checkpoint 12 were immutable
+query experiments: their older mutation methods do not rebuild every new
+sidecar. Use `new()` plus queries while learning those stages. Checkpoint 13 is
+where the exercise becomes mutation-safe.
+
+## The contract that never changes
+
+Intervals and queries are half-open:
+
+```text
+interval = [interval.start, interval.stop)
+query    = [query.start, query.stop)
+```
+
+They overlap only when both strict comparisons pass:
+
+```rust
+interval.start < query_stop && interval.stop > query_start
+```
+
+Equality means no overlap. An interval ending at `query_start` is to the left;
+an interval starting at `query_stop` is to the right.
+
+The observable identity of this design is also fixed:
+
+- `intervals` is the one canonical vector;
+- it is sorted by `(start, stop)` during construction;
+- queries yield borrowed entries from that vector;
+- results appear in increasing vector position, hence start order; and
+- no index may omit a true overlap or invent a false one.
+
+The index may skip, classify, or compare many entries together. It may not
+reorder the canonical vector or return results backward.
+
+## Checkpoint 0: make brute force the executable specification
+
+Before adding an index, add an integration test that calculates the answer in the
+most obvious way and compares values in order. This is more important than a
+count-only test: two iterators can return the same count while returning the
+wrong entries or order.
+
+Create `tests/block_index.rs`:
+
+```rust
+use rust_lapper::{Interval, Lapper};
+
+#[test]
+fn block_index_matches_forward_brute_force() {
+    let mut state = 0x1234_5678_u64;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (state >> 32) as u32
+    };
+
+    let mut intervals = vec![Interval {
+        start: 0,
+        stop: 1_000_000,
+        val: 0usize,
+    }];
+    for value in 1..5000 {
+        let start = next() % 1_000_000;
+        let len = 1 + next() % 1000;
+        intervals.push(Interval {
+            start,
+            stop: start + len,
+            val: value,
+        });
+    }
+    let lapper = Lapper::new(intervals);
+
+    for _ in 0..20_000 {
+        let start = next() % 1_000_000;
+        let stop = start + 1 + next() % 2000;
+        let got: Vec<_> = lapper.find(start, stop).map(|iv| iv.val).collect();
+        let expected: Vec<_> = lapper
+            .intervals
+            .iter()
+            .filter(|iv| iv.start < stop && iv.stop > start)
+            .map(|iv| iv.val)
+            .collect();
+        assert_eq!(got, expected, "query {start}..{stop}");
+    }
+}
+```
+
+### Invariant
+
+The expected vector is produced by filtering the canonical start-sorted vector
+without skipping or reordering. It is the oracle for every later iterator.
+
+### Work it by hand
+
+For intervals `[0, 3)`, `[2, 8)`, `[5, 7)`, and `[9, 12)`, query `[3, 6)`:
+
+```text
+[0, 3):  0 < 6, but 3 > 3 is false
+[2, 8):  2 < 6 and 8 > 3 -> hit
+[5, 7):  5 < 6 and 7 > 3 -> hit
+[9, 12): 9 < 6 is false; all later starts also fail
+
+answer: the second interval, then the third interval
+```
+
+### Pass the gate
 
 ```bash
 cargo test --test block_index
 ```
 
-The test checks the count, the exact interval references, and forward order
-against brute force over randomized inputs.
+Do not proceed until this passes on `baseline/v1.3.0`.
 
-## 1. Store ends in start order
+## Checkpoint 1: understand the original search
 
-The canonical interval vector and `starts` already share start order. Add one
-sidecar that preserves each interval's stop in that same order:
+Original Lapper stores:
 
-```rust
-stops_by_start: Vec<I>,
+```text
+intervals  canonical intervals sorted by (start, stop)
+starts     starts sorted globally
+stops      stops sorted globally, no longer paired with starts
+max_len    length of the longest interval
 ```
 
-Build it before sorting the separate `stops` vector used by `count()`:
+`find(query_start, query_stop)` computes a conservative earliest possible start:
+
+```rust
+let earliest_start = query_start
+    .checked_sub(&self.max_len)
+    .unwrap_or_else(zero::<I>);
+let off = Self::lower_bound(earliest_start, &self.intervals);
+```
+
+Why it is safe: no interval starting before `query_start - max_len` can be long
+enough to reach `query_start`. From `off`, the iterator checks intervals one by
+one and stops forever when `interval.start >= query_stop`.
+
+### Invariant
+
+Sorted starts prove the right-hand stopping condition. `max_len` proves the
+left-hand starting condition.
+
+### Work it by hand
+
+If `query_start = 1_000` and `max_len = 40`, no interval starting before `960`
+can reach the query. But one extremely long interval makes `max_len` enormous,
+pushes `earliest_start` back toward zero, and forces nearly every query to scan a
+large prefix. That is the pathological case the new index must repair.
+
+### Pass the gate
+
+Be able to answer these before continuing:
+
+```text
+Why can the iterator stop on interval.start >= query_stop?
+Why can it not stop merely because one interval.stop <= query_start?
+Why does one global long interval make max_len a weak lower bound?
+```
+
+## Checkpoint 2: add one next-greater link per interval
+
+The first index asks: if interval `i` ends too early, which later interval is the
+first one whose end is strictly greater?
+
+Add one sidecar:
+
+```rust
+jump_index: Vec<usize>,
+```
+
+Build it in linear time with a monotonic stack, scanning right to left:
+
+```rust
+let interval_count = intervals.len();
+let mut jump_index = vec![interval_count; interval_count];
+let mut stack = Vec::<usize>::new();
+
+for i in (0..interval_count).rev() {
+    while stack
+        .last()
+        .is_some_and(|j| intervals[*j].stop <= intervals[i].stop)
+    {
+        stack.pop();
+    }
+    jump_index[i] = stack.last().copied().unwrap_or(interval_count);
+    stack.push(i);
+}
+```
+
+Why the stack gives the *nearest* greater end:
+
+- before processing `i`, the stack contains undominated positions to its right;
+- viewed from the top outward, their ends are strictly increasing;
+- anything popped has an end no greater than `end[i]` and is farther right, so
+  `i` is both closer and at least as capable of reaching a future query;
+- after those dominated entries are removed, the top is the closest surviving
+  position with an end strictly greater than `end[i]`.
+
+That domination argument is why construction is linear: every position is
+pushed once and popped at most once.
+
+Then replace the scalar miss step with the link:
+
+```rust
+while self.off < self.inner.intervals.len() {
+    let interval = &self.inner.intervals[self.off];
+
+    if interval.start >= self.stop {
+        break;
+    }
+    if interval.stop > self.start {
+        self.off += 1;
+        return Some(interval);
+    }
+
+    self.off = self.inner.jump_index[self.off];
+}
+```
+
+### Invariant
+
+Suppose `jump_index[i] = j`. Every index strictly between `i` and `j` has
+`stop <= intervals[i].stop`. The link is used only after proving
+`intervals[i].stop <= query_start`, so every skipped interval also ends at or
+before the query and cannot overlap.
+
+The link points right, so forward order is preserved.
+
+### Work it by hand
+
+For start-ordered end values:
+
+```text
+index: 0  1  2  3  4
+end:   7  3  5  2  9
+link:  4  2  4  4  sentinel
+```
+
+With `query_start = 6`, a miss at index 1 follows `1 -> 2 -> 4`:
+
+```text
+end[1] = 3 <= 6
+end[2] = 5 <= 6
+end[4] = 9 > 6
+```
+
+Index 3 is skipped by `2 -> 4` because its end `2` is no greater than end `5`.
+
+### Pass the gate
+
+```bash
+cargo test --test block_index
+git diff contender/per-interval -- src/lib.rs
+```
+
+This historical branch is an immutable-query experiment. Its `insert()` and
+`merge_overlaps()` paths do not rebuild the new link array. Do not treat that as
+production-correct; mutation is repaired in checkpoint 13.
+
+## Checkpoint 3: amortize the index over fixed blocks
+
+The per-interval index costs one `usize` per interval and performs irregular link
+work for individual misses. Replace it with one summary for each 32 consecutive
+intervals:
+
+```rust
+const INDEX_BLOCK_SIZE: usize = 32;
+
+block_index: Vec<usize>,
+block_max_ends: Vec<I>,
+block_prefix_max_ends: Vec<I>,
+```
+
+First calculate each block's maximum end:
+
+```rust
+let mut block_max_ends = Vec::new();
+for block in intervals.chunks(INDEX_BLOCK_SIZE) {
+    let mut max_end = block[0].stop;
+    for interval in &block[1..] {
+        max_end = std::cmp::max(max_end, interval.stop);
+    }
+    block_max_ends.push(max_end);
+}
+```
+
+Run the same next-greater construction over block maxima:
+
+```rust
+let block_count = block_max_ends.len();
+let mut block_index = vec![block_count; block_count];
+let mut stack = Vec::<usize>::new();
+
+for block in (0..block_count).rev() {
+    while stack
+        .last()
+        .is_some_and(|next| block_max_ends[*next] <= block_max_ends[block])
+    {
+        stack.pop();
+    }
+    block_index[block] = stack.last().copied().unwrap_or(block_count);
+    stack.push(block);
+}
+```
+
+At a block boundary, skip only when the entire block is an exact miss:
+
+```rust
+let block = block_start / INDEX_BLOCK_SIZE;
+if self.inner.block_max_ends[block] <= self.start {
+    self.next_block_start =
+        self.inner.block_index[block] * INDEX_BLOCK_SIZE;
+    continue;
+}
+```
+
+### Invariant
+
+`block_max_end <= query_start` proves every end in the block fails the strict
+`end > query_start` overlap test. If the link jumps from block `b` to block `j`,
+all intermediate block maxima are no greater than `max_end[b]`, so they also
+fail.
+
+### Work it by hand
+
+Use a paper-only block size of four. The real implementation remains 32.
+
+| Block | Start-ordered intervals | Minimum end | Maximum end |
+|---|---|---:|---:|
+| 0 | `[0,4) [2,30) [5,7) [8,9)` | 4 | 30 |
+| 1 | `[10,12) [13,14) [15,18) [19,21)` | 12 | 21 |
+| 2 | `[22,60) [24,25) [27,35) [40,44)` | 25 | 60 |
+
+The block maxima are `[30, 21, 60]`, so the links are `[2, 2, sentinel]`.
+For query `[23, 28)`, block 1 has `max_end = 21 <= 23` and can jump directly to
+block 2.
+
+### Pass the gate
+
+```bash
+cargo test --test block_index
+git diff contender/block-32 -- src/lib.rs
+```
+
+Explain why a block maximum can prove an all-miss block but cannot prove which
+individual intervals hit inside a candidate block.
+
+## Checkpoint 4: add the prefix maximum entry search
+
+`find()` should not enter block zero for every query. Build a monotonically
+nondecreasing prefix over block maxima:
+
+```rust
+let mut block_prefix_max_ends = block_max_ends.clone();
+for block in 1..block_prefix_max_ends.len() {
+    block_prefix_max_ends[block] = std::cmp::max(
+        block_prefix_max_ends[block - 1],
+        block_prefix_max_ends[block],
+    );
+}
+```
+
+Binary-search it at query creation:
+
+```rust
+let first_block = self
+    .block_prefix_max_ends
+    .partition_point(|max_end| *max_end <= query_start);
+let next_block_start = first_block * INDEX_BLOCK_SIZE;
+```
+
+### Invariant
+
+If `prefix_max[b] <= query_start`, every interval in every block through `b`
+ends too early. The first prefix value greater than `query_start` is therefore
+the first block that could contain an overlap.
+
+### Work it by hand
+
+For block maxima `[30, 21, 60]`, the prefix maxima are `[30, 30, 60]`.
+
+```text
+query_start = 23 -> partition point 0 -> block 0 may contain [2,30)
+query_start = 31 -> partition point 2 -> blocks 0 and 1 are impossible
+query_start = 61 -> partition point 3 -> no block can overlap
+```
+
+### Pass the gate
+
+Add assertions for those three partition points or write them on paper before
+running:
+
+```bash
+cargo test --test block_index
+```
+
+Notice that final `find()` no longer depends on global `max_len`; `seek()` still
+uses it to advance a cursor for sorted query streams.
+
+## Checkpoint 5: add exact candidate-block routes
+
+Maximum ends prove an all-miss route. Add the complementary minimum end:
+
+```rust
+block_min_ends: Vec<I>,
+```
+
+Calculate minimum and maximum together. Also preserve ends in start order:
 
 ```rust
 let (starts, mut stops): (Vec<_>, Vec<_>) =
-    intervals.iter().map(|x| (x.start, x.stop)).unzip();
+    intervals.iter().map(|iv| (iv.start, iv.stop)).unzip();
 let stops_by_start = stops.clone();
+stops.sort();
 ```
 
-Why: a SIMD lane must load the start and stop for the same interval. The sorted
-`stops` array cannot provide that pairing.
-
-## 2. Add exact block facts
-
-For every 32-entry block, retain both its minimum and maximum stop. Also build a
-prefix maximum over block maxima.
-
-The three facts have separate jobs:
+These two end arrays are intentionally different:
 
 ```text
-max_end <= query.start  -> every lane misses; follow the skip link
-min_end > query.start   -> every active lane's end passes
-otherwise               -> the block is mixed; calculate a mask
-prefix_max <= start     -> binary-search directly to the first possible block
+stops           globally sorted; used by count()
+stops_by_start  lane i belongs to starts[i]; used by block masks
 ```
 
-These are proofs, not a workload score.
+Every candidate block now has three exact routes:
 
-## 3. Give the iterator memory
+```text
+max_end <= query_start
+    -> all miss; follow the forward block link
 
-Add state for one query-local answer:
+min_end > query_start
+    -> every end passes; return only starts < query_stop
+
+otherwise
+    -> end results are mixed; calculate every lane exactly
+```
+
+For the all-ends-pass route, sorted starts identify one dense prefix:
 
 ```rust
+let starts = &self.inner.starts[block_start..block_end];
+let active_len = starts.partition_point(|start| *start < self.stop);
+self.dense_next = block_start;
+self.dense_end = block_start + active_len;
+```
+
+### Invariant
+
+`min_end > query_start` proves the end half of overlap for every lane. It does
+not prove the start half. The active prefix is still needed because starts at or
+after `query_stop` do not overlap.
+
+This answers the active-prefix question precisely:
+
+- dense route: yes, find the active start prefix;
+- mixed route: no separate prefix is needed once the mask checks both predicates;
+- whole query: stop forever when the first start of a block is at or beyond
+  `query_stop`.
+
+### Work it by hand
+
+Return to query `[23, 28)` in the three toy blocks:
+
+```text
+block 0: min 4 <= 23 < max 30 -> mixed
+block 1: max 21 <= 23         -> jump
+block 2: min 25 > 23          -> every end passes
+```
+
+Block 2 starts are `[22, 24, 27, 40]`. Its active prefix is the first three
+lanes because `22`, `24`, and `27` are less than `28`; `40` is not.
+
+### Pass the gate
+
+Before adding SIMD, write down why both inequalities are strict:
+
+```text
+max_end == query_start -> all miss
+min_end == query_start -> not all ends pass
+start == query_stop    -> lane misses
+```
+
+## Checkpoint 6: save one scalar block mask
+
+Add a temporary `find_block_mask()` iterator while retaining normal `find()` as
+the control. This is scaffolding for the experiment, not a permanent API or a
+mode switch.
+
+Give the iterator memory:
+
+```rust
+next_block_start: usize,
 mask_block_start: usize,
 mask: u32,
 dense_next: usize,
 dense_end: usize,
+start: u32,
+stop: u32,
 ```
 
-At the top of `next()`, drain a dense prefix first, then a saved mask:
-
-```rust
-if self.mask != 0 {
-    let lane = self.mask.trailing_zeros() as usize;
-    self.mask &= self.mask - 1;
-    return Some(&self.inner.intervals[self.mask_block_start + lane]);
-}
-```
-
-`trailing_zeros()` selects the lowest lane. `mask & (mask - 1)` erases that lane.
-Those two operations are the forward-order contract.
-
-## 4. Make a scalar mask before using NEON
-
-Write and test this version first:
+Start with a scalar mask that is obviously equivalent to brute force:
 
 ```rust
 fn overlap_mask(
@@ -100,7 +582,7 @@ fn overlap_mask(
     query_start: u32,
     query_stop: u32,
 ) -> u32 {
-    let mut mask = 0;
+    let mut mask = 0_u32;
     for lane in 0..starts.len() {
         if stops[lane] > query_start && starts[lane] < query_stop {
             mask |= 1 << lane;
@@ -110,94 +592,903 @@ fn overlap_mask(
 }
 ```
 
-Do not move on until the randomized test passes. SIMD must be only another way to
-compute this exact integer.
-
-## 5. Type one four-lane NEON comparison
-
-On AArch64, one 128-bit register holds four `u32` lanes:
+Drain the lowest saved bit across later `next()` calls:
 
 ```rust
+if self.mask != 0 {
+    let lane = self.mask.trailing_zeros() as usize;
+    self.mask &= self.mask - 1;
+    return Some(&self.inner.intervals[self.mask_block_start + lane]);
+}
+```
+
+The full safe state machine is:
+
+```rust
+loop {
+    if self.dense_next < self.dense_end {
+        let index = self.dense_next;
+        self.dense_next += 1;
+        return Some(&self.inner.intervals[index]);
+    }
+
+    if self.mask != 0 {
+        let lane = self.mask.trailing_zeros() as usize;
+        self.mask &= self.mask - 1;
+        return Some(&self.inner.intervals[self.mask_block_start + lane]);
+    }
+
+    let block_start = self.next_block_start;
+    if block_start >= self.inner.starts.len()
+        || self.inner.starts[block_start] >= self.stop
+    {
+        return None;
+    }
+
+    let block = block_start / INDEX_BLOCK_SIZE;
+    if self.inner.block_max_ends[block] <= self.start {
+        self.next_block_start =
+            self.inner.block_index[block] * INDEX_BLOCK_SIZE;
+        continue;
+    }
+
+    let block_end =
+        (block_start + INDEX_BLOCK_SIZE).min(self.inner.starts.len());
+
+    if self.inner.block_min_ends[block] > self.start {
+        let starts = &self.inner.starts[block_start..block_end];
+        let active_len =
+            starts.partition_point(|lane_start| *lane_start < self.stop);
+        self.dense_next = block_start;
+        self.dense_end = block_start + active_len;
+        self.next_block_start = if active_len == starts.len() {
+            block_end
+        } else {
+            self.inner.starts.len()
+        };
+        continue;
+    }
+
+    self.mask_block_start = block_start;
+    self.next_block_start = block_end;
+    self.mask = overlap_mask(
+        &self.inner.starts[block_start..block_end],
+        &self.inner.stops_by_start[block_start..block_end],
+        self.start,
+        self.stop,
+    );
+}
+```
+
+### Invariant
+
+Bit `k` describes lane `k` in one block. `trailing_zeros()` selects the lowest
+remaining lane, and `mask & (mask - 1)` erases exactly that bit. Blocks only move
+right. Therefore output remains in canonical vector order.
+
+### Work it by hand
+
+For toy block 0 and query `[23, 28)`:
+
+```text
+lane 0 [0,4)  -> 0
+lane 1 [2,30) -> 1
+lane 2 [5,7)  -> 0
+lane 3 [8,9)  -> 0
+
+mask = 0b0010
+trailing_zeros(mask) = 1
+next() returns canonical index block_start + 1
+```
+
+Across all blocks the result indices are `[1, 8, 9, 10]`, still in start order.
+
+### Pass the gate
+
+Temporarily extend the oracle test:
+
+```rust
+let got_mask: Vec<_> = lapper
+    .find_block_mask(start, stop)
+    .map(|iv| iv.val)
+    .collect();
+assert_eq!(got_mask, expected);
+```
+
+Then run:
+
+```bash
+cargo test --test block_index
+```
+
+Do not type an intrinsic until the scalar mask passes.
+
+## Checkpoint 7: compute four `u32` lanes with NEON
+
+On AArch64, one 128-bit NEON register holds four `u32` values. Inside an
+`unsafe` block, broadcast the query bounds once, then load and compare four
+paired intervals:
+
+```rust
+use std::arch::aarch64::*;
+
+let query_start_v = vdupq_n_u32(query_start);
+let query_stop_v = vdupq_n_u32(query_stop);
+
 let lane_starts = vld1q_u32(starts.as_ptr().add(lane));
 let lane_stops = vld1q_u32(stops.as_ptr().add(lane));
 
-let overlapping = vandq_u32(
+let overlaps = vandq_u32(
     vcgtq_u32(lane_stops, query_start_v),
     vcgtq_u32(query_stop_v, lane_starts),
 );
 ```
 
-Read the comparisons literally:
+Read that literally:
 
 ```text
-interval.stop > query.start
-query.stop > interval.start
+lane_stops > query_start
+query_stop > lane_starts
 ```
 
-Each true lane is `0xffff_ffff`; each false lane is zero.
+NEON comparison results are not scalar booleans. A true `u32` lane contains
+`0xffff_ffff`; a false lane contains zero.
 
-## 6. Turn four truth lanes into four bits
+For the first version, shift truth down to zero/one and extract each lane:
 
-Type the weighted reduction once:
+```rust
+let bits = vshrq_n_u32::<31>(overlaps);
+mask |= vgetq_lane_u32::<0>(bits) << lane;
+mask |= vgetq_lane_u32::<1>(bits) << (lane + 1);
+mask |= vgetq_lane_u32::<2>(bits) << (lane + 2);
+mask |= vgetq_lane_u32::<3>(bits) << (lane + 3);
+```
+
+Keep a scalar tail for a final block whose length is not divisible by four.
+
+### Invariant
+
+The SIMD function must return the exact same `u32` as checkpoint 6. It does not
+get a new definition of overlap, block membership, or order.
+
+### Work it by hand
+
+Truth lanes `[true, false, true, true]` become:
+
+```text
+[0xffff_ffff, 0, 0xffff_ffff, 0xffff_ffff]
+shift by 31 -> [1, 0, 1, 1]
+packed mask -> 0b1101
+```
+
+### Pass the gate
+
+```bash
+cargo test --test block_index
+git diff contender/simd-mask -- src/lib.rs tests/block_index.rs
+```
+
+On non-AArch64, retain the scalar mask under `cfg` so the branch still compiles.
+
+## Checkpoint 8: replace lane extraction with weighted bits
+
+Each true lane is already all ones. Give each lane the numeric value of its final
+bit:
 
 ```rust
 let weights = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
-let bits = vaddvq_u32(vandq_u32(overlapping, weights));
+let bits = vaddvq_u32(vandq_u32(overlaps, weights));
 mask |= bits << lane;
 ```
 
-A true lane keeps its weight and a false lane keeps zero. Adding
-`[1, 0, 4, 8]` gives `13`, whose binary representation is `1101`. The sum is the
-mask; it is not a count.
+This is the complete explanation of the apparent magic:
 
-## 7. Load and pack eight lanes
+```text
+truths:       [all ones, zero, all ones, all ones]
+weights:      [1,        2,    4,        8       ]
+after AND:    [1,        0,    4,        8       ]
+horizontal +: 13
+binary 13:    0b1101
+```
 
-Replace two four-lane iterations with one paired load:
+The sum is a mask, not a count. Powers of two cannot carry into each other
+because each weight appears at most once.
+
+### Invariant
+
+Lane `k` contributes exactly `1 << k` if and only if it overlaps.
+
+### Work it by hand
+
+Calculate these without Rust:
+
+```text
+[false, true, false, true] -> 2 + 8 = 10 -> 0b1010
+[true, true, true, true]   -> 1 + 2 + 4 + 8 = 15 -> 0b1111
+[false, false, false, false] -> 0
+```
+
+### Pass the gate
+
+```bash
+cargo test --test block_index
+git diff contender/simd-mask-addv -- src/lib.rs
+```
+
+## Checkpoint 9: load and pack eight lanes
+
+First load two adjacent NEON registers at once:
 
 ```rust
 let lane_starts = vld1q_u32_x2(starts.as_ptr().add(lane));
 let lane_stops = vld1q_u32_x2(stops.as_ptr().add(lane));
 ```
 
-Compare `.0` and `.1` independently. Then narrow and join their all-ones/all-zero
-answers:
+Compare `.0` and `.1` independently. The intermediate paired-load checkpoint
+uses two four-lane reductions:
 
 ```rust
-let overlapping = vcombine_u16(
-    vmovn_u32(overlapping0),
-    vmovn_u32(overlapping1),
+let bits0 = vaddvq_u32(vandq_u32(overlaps0, weights4));
+let bits1 = vaddvq_u32(vandq_u32(overlaps1, weights4));
+mask |= (bits0 | (bits1 << 4)) << lane;
+```
+
+Then narrow the two all-ones/all-zero vectors into eight `u16` truth lanes and
+reduce only once:
+
+```rust
+let eight_truths = vcombine_u16(
+    vmovn_u32(overlaps0),
+    vmovn_u32(overlaps1),
 );
-let weights = vld1q_u16(
+let weights8 = vld1q_u16(
     [1_u16, 2, 4, 8, 16, 32, 64, 128].as_ptr(),
 );
-let bits = vaddvq_u16(vandq_u16(overlapping, weights));
+let bits = vaddvq_u16(vandq_u16(eight_truths, weights8));
 mask |= u32::from(bits) << lane;
 ```
 
-Narrowing does not lose truth: the low 16 bits of all ones are still all ones.
-This lets one `addv.8h` produce eight bits instead of two `addv.4s` reductions.
+Narrowing preserves truth: the low 16 bits of all ones are still all ones, and
+zero stays zero.
 
-Keep the four-lane loop for a partial final block, and keep a scalar tail for a
-length not divisible by four.
+Retain this loop structure:
 
-## 8. Inspect what the compiler made
+```text
+while at least 8 lanes remain -> paired eight-lane path
+while at least 4 lanes remain -> single four-lane path
+while any lanes remain        -> scalar tail
+```
 
-Ask rustc to retain assembly for the release library:
+### Invariant
+
+The eight-lane result owns eight consecutive mask bits beginning at `lane`.
+Neither paired loads nor narrowing changes which interval belongs to a lane.
+
+### Work it by hand
+
+For truth lanes:
+
+```text
+[true, false, true, true, false, false, true, false]
+```
+
+the kept weights are `[1, 0, 4, 8, 0, 0, 64, 0]`, whose sum is `77`, or
+`0b0100_1101`.
+
+### Pass the gate
+
+```bash
+cargo test --test block_index
+git diff contender/simd-mask-addv-ld1x2 -- src/lib.rs
+git diff contender/simd-mask-narrow8-ld1x2 -- src/lib.rs
+```
+
+## Checkpoint 10: inspect the generated AArch64 instructions
+
+Do not add handwritten assembly because the intrinsic source looks verbose.
+Inspect what LLVM actually emitted:
 
 ```bash
 RUSTFLAGS='-C target-cpu=native' \
   cargo rustc --release --lib -- --emit=asm
+
 rg -n 'ldp|uzp1|addv' target/release/deps/rust_lapper-*.s
 ```
 
-The measured Apple M3 path contains paired `ldp` vector loads, `uzp1.8h`, and
-`addv.8h`. Handwritten assembly is unnecessary for this core.
+On the measured Apple M3 path:
 
-## Stop here once
+```text
+ldp q..., q...  paired vector loads
+uzp1.8h         narrow/join the relevant halfwords
+addv.8h         horizontal weighted reduction
+```
 
-At this point you have typed every important ARM operation and can compare the
-whole answer against `tutorial/aarch64-u32-hand-typed`. The production-oriented
-`worked/portable-simd-index` branch deliberately moves type dispatch, mutation
-rebuilding, x86 AVX2, scalar fallback, and audited `get_unchecked` calls into
-separate helpers. Those abstractions are useful after the mechanics are familiar;
-they are noise during this first pass.
+### Invariant
+
+Intrinsics define semantics; assembly inspection tells you the final cost. Add
+inline assembly only when a specific unwanted instruction remains and a measured
+replacement wins. That condition was not met here.
+
+### Work it by hand
+
+For one eight-lane group, account for the conceptual work before reading the
+assembly:
+
+```text
+two vector registers of starts
+two vector registers of stops
+two end comparisons
+two start comparisons
+two ANDs
+one narrow/join
+one weighted AND
+one horizontal reduction
+```
+
+Then identify which instructions LLVM combined or folded. In particular, verify
+that you do not see eight scalar loads or eight scalar branches.
+
+### Pass the gate
+
+Find the paired loads and one eight-halfword reduction in your release assembly.
+The randomized correctness test is still mandatory; assembly shape cannot prove
+the lane-to-bit mapping.
+
+## Checkpoint 11: make the mask iterator the normal API
+
+The temporary `find_block_mask()` method was useful for A/B testing. Remove it
+and put its state into the existing generic `IterFind`. `find()` initializes the
+first block from prefix maxima:
+
+```rust
+let off = self
+    .block_prefix_max_ends
+    .partition_point(|max_end| *max_end <= start)
+    * INDEX_BLOCK_SIZE;
+
+IterFind {
+    inner: self,
+    next_block_start: off,
+    mask_block_start: 0,
+    mask: 0,
+    dense_next: 0,
+    dense_end: 0,
+    backend: detect_backend(),
+    start,
+    stop,
+}
+```
+
+`seek()` still uses its sorted-query cursor and `max_len`, but it must round down
+to the containing block:
+
+```rust
+next_block_start: (*cursor / INDEX_BLOCK_SIZE) * INDEX_BLOCK_SIZE,
+```
+
+Rounding up would miss earlier lanes in the cursor's block that can still overlap
+the query. The mask will reject lanes that are actually too early.
+
+### Invariant
+
+The API has one query algorithm. Backend selection changes how a mixed mask is
+calculated, not whether the block index is used.
+
+### Work it by hand
+
+If `cursor = 45` and block size is 32, the containing block begins at 32, not 64.
+A long interval at lane 35 may overlap even though the cursor has advanced to 45.
+
+### Pass the gate
+
+Remove the temporary `got_mask` test path. The ordinary call must now pass the
+same oracle:
+
+```bash
+cargo test --test block_index
+rg -n 'find_block_mask' src tests
+```
+
+The final `rg` should return nothing.
+
+## Checkpoint 12: separate the mask backend and support integer widths
+
+Move mask generation to private `src/simd.rs`. Keep one semantic entry point:
+
+```rust
+pub(crate) fn overlap_mask<I>(
+    backend: MaskBackend,
+    starts: &[I],
+    stops: &[I],
+    query_start: I,
+    query_stop: I,
+) -> u32
+where
+    I: PrimInt + 'static,
+```
+
+Select only CPU capability:
+
+```rust
+pub(crate) enum MaskBackend {
+    Scalar,
+    #[cfg(target_arch = "aarch64")]
+    Neon,
+    #[cfg(target_arch = "x86_64")]
+    Avx2,
+}
+
+pub(crate) fn detect_backend() -> MaskBackend {
+    #[cfg(target_arch = "aarch64")]
+    {
+        return MaskBackend::Neon;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::is_x86_feature_detected!("avx2") {
+            return MaskBackend::Avx2;
+        }
+    }
+
+    #[allow(unreachable_code)]
+    MaskBackend::Scalar
+}
+```
+
+Use exact `TypeId` checks before reinterpreting a generic slice as a primitive
+slice. This is why the generic query implementation acquires `I: 'static`:
+
+```rust
+if TypeId::of::<I>() == TypeId::of::<u32>() {
+    let starts = unsafe {
+        std::slice::from_raw_parts(
+            starts.as_ptr().cast::<u32>(),
+            starts.len(),
+        )
+    };
+    // Convert stops and query bounds under the same exact-type proof.
+    return unsafe { neon::mask_u32(starts, stops, query_start, query_stop) };
+}
+```
+
+Do not dispatch from `size_of::<I>()` alone. A custom integer wrapper can have
+the same size without having a primitive integer's layout. Unknown `PrimInt`
+implementations must use the scalar mask.
+
+The AArch64 packing map is:
+
+| Type | Values in paired 128-bit loads | Packing idea |
+|---|---:|---|
+| `u8` / `i8` | 32 | weighted byte halves |
+| `u16` / `i16` | 16 | narrow truth to bytes |
+| `u32` / `i32` | 8 | narrow truth to halfwords |
+| `u64` / `i64` | 4 | narrow truth to words |
+
+On x86-64 AVX2:
+
+| Type | Values per 256-bit vector | Bit extraction |
+|---|---:|---|
+| `u8` / `i8` | 32 | `_mm256_movemask_epi8` |
+| `u16` / `i16` | 16 | byte movemask, then compact duplicate bits |
+| `u32` / `i32` | 8 | `_mm256_movemask_ps` |
+| `u64` / `i64` | 4 | `_mm256_movemask_pd` |
+
+AVX2 integer greater-than operations are signed. For unsigned types, XOR both
+operands with the sign bit before the signed comparison:
+
+```text
+unsigned order: 0 ............ MAX
+XOR sign bit:   MIN_SIGNED ... MAX_SIGNED
+```
+
+The transform preserves order while moving it into the signed domain.
+
+### Invariant
+
+Every backend returns the same `u32` lane mask. CPU dispatch is not workload
+selection. `usize`/`isize` are mapped only to their exact 64-bit representation
+on these 64-bit targets.
+
+### Work it by hand
+
+Explain why an AVX2 `u16` comparison produces two identical sign bits in the
+byte movemask for each true lane, and why those bits must be compacted to one bit
+per interval.
+
+### Pass the gate
+
+```bash
+cargo test --all-features
+cargo test --target x86_64-apple-darwin --all-features --lib
+cargo clippy --target wasm32-wasip1 --lib --all-features -- -D warnings
+```
+
+The Rosetta x86 test may take the scalar backend if AVX2 is not advertised. A
+forced-Haswell assembly build is a separate instruction check, not native x86
+performance evidence.
+
+## Checkpoint 13: make every derived array rebuildable
+
+At this point the query is fast but historical mutation paths leave new metadata
+stale. Treat `intervals` as the source of truth and centralize all sidecar
+construction:
+
+```rust
+fn rebuild_derived(&mut self) {
+    let (starts, stops_by_start): (Vec<_>, Vec<_>) = self
+        .intervals
+        .iter()
+        .map(|interval| (interval.start, interval.stop))
+        .unzip();
+
+    self.starts = starts;
+    self.stops = stops_by_start.clone();
+    self.stops_by_start = stops_by_start;
+
+    self.max_len = self
+        .intervals
+        .iter()
+        .map(|interval| {
+            interval
+                .stop
+                .checked_sub(&interval.start)
+                .unwrap_or_else(zero::<I>)
+        })
+        .max()
+        .unwrap_or_else(zero::<I>);
+
+    self.stops.sort();
+
+    self.block_max_ends.clear();
+    self.block_min_ends.clear();
+    let block_count = self.intervals.len().div_ceil(INDEX_BLOCK_SIZE);
+
+    for block in self.intervals.chunks(INDEX_BLOCK_SIZE) {
+        let mut max_end = block[0].stop;
+        let mut min_end = max_end;
+        for interval in &block[1..] {
+            max_end = std::cmp::max(max_end, interval.stop);
+            min_end = std::cmp::min(min_end, interval.stop);
+        }
+        self.block_max_ends.push(max_end);
+        self.block_min_ends.push(min_end);
+    }
+
+    self.block_index.clear();
+    self.block_index.resize(block_count, block_count);
+    let mut stack = Vec::<usize>::new();
+    for block in (0..block_count).rev() {
+        while stack.last().is_some_and(|next| {
+            self.block_max_ends[*next] <= self.block_max_ends[block]
+        }) {
+            stack.pop();
+        }
+        self.block_index[block] =
+            stack.last().copied().unwrap_or(block_count);
+        stack.push(block);
+    }
+
+    self.block_prefix_max_ends
+        .clone_from(&self.block_max_ends);
+    for block in 1..block_count {
+        self.block_prefix_max_ends[block] = std::cmp::max(
+            self.block_prefix_max_ends[block - 1],
+            self.block_prefix_max_ends[block],
+        );
+    }
+}
+```
+
+Preserve the existing `sort_unstable` feature branches around the two sorts in
+the actual source.
+
+Call `rebuild_derived()` from:
+
+```text
+new()
+insert(), after inserting into canonical order
+merge_overlaps(), after replacing intervals
+deserialize(), by constructing through new()
+```
+
+Do not serialize CPU- or implementation-specific sidecars. Custom serde writes
+the original six fields and rebuilds the new private fields from `intervals` on
+read.
+
+The serialization side deliberately names only the original fields:
+
+```rust
+let mut state = serializer.serialize_struct("Lapper", 6)?;
+state.serialize_field("intervals", &self.intervals)?;
+state.serialize_field("starts", &self.starts)?;
+state.serialize_field("stops", &self.stops)?;
+state.serialize_field("max_len", &self.max_len)?;
+state.serialize_field("cov", &self.cov)?;
+state.serialize_field("overlaps_merged", &self.overlaps_merged)?;
+state.end()
+```
+
+Deserialize those six fields into a helper, but trust only the canonical
+intervals as structural input:
+
+```rust
+let serialized = SerializedLapper::<I, T>::deserialize(deserializer)?;
+let mut lapper = Self::new(serialized.intervals);
+lapper.cov = serialized.cov;
+lapper.overlaps_merged = serialized.overlaps_merged;
+Ok(lapper)
+```
+
+The serialized `starts`, `stops`, and `max_len` fields remain in the helper for
+wire compatibility, but `new()` recalculates them and every new sidecar. This
+also prevents stale or inconsistent serialized metadata from entering the unsafe
+query proof.
+
+### Invariant
+
+After every supported mutation:
+
+```text
+starts.len() == stops_by_start.len()
+metadata.len() == ceil(starts.len() / 32)
+starts[i] and stops_by_start[i] describe canonical interval i
+every block link is a valid later block or the block-count sentinel
+```
+
+### Work it by hand
+
+Insert a new interval at canonical index 17. Every later lane position changes,
+and potentially every block minimum, maximum, link, and prefix maximum changes.
+Updating only `starts` and `stops` cannot be correct. A full rebuild is simple and
+appropriate because `insert()` is already documented as inefficient.
+
+### Pass the gate
+
+Add tests that cross several block boundaries:
+
+```bash
+cargo test --all-features insert_rebuilds_every_query_index
+cargo test --all-features merge_rebuilds_every_query_index
+cargo test --all-features serde_test
+```
+
+## Checkpoint 14: remove unsigned assumptions
+
+Supporting signed primitive coordinates requires more than writing signed SIMD
+comparisons.
+
+Remove the `Unsigned` bound, then repair three scalar assumptions.
+
+For `seek()`, saturation belongs at the type minimum, not zero:
+
+```rust
+let earliest_start = start
+    .checked_sub(&self.max_len)
+    .unwrap_or_else(I::min_value);
+```
+
+For `count()`, avoid `start + 1`, which can overflow at the coordinate maximum:
+
+```rust
+let ends_before_or_at_start = self
+    .stops
+    .partition_point(|interval_stop| *interval_stop <= start);
+let starts_before_stop = Self::bsearch_seq(stop, &self.starts);
+
+let count = starts_before_stop - ends_before_or_at_start;
+```
+
+The source expresses the same arithmetic through total length and excluded
+suffix count. The identity is:
+
+```text
+overlaps = intervals with start < query_stop
+         - intervals with stop <= query_start
+```
+
+For `depth()`, zero cannot be an uninitialized sentinel. Add an explicit
+`initialized: bool` so a coverage interval crossing zero starts at its real
+negative coordinate.
+
+### Invariant
+
+Zero is an ordinary coordinate. Overflow behavior and iterator initialization
+must not give it special semantic meaning.
+
+### Work it by hand
+
+For ends `[-10, -2, 4, 9]` and query start `-2`, exactly the first two ends are
+`<= -2` and cannot overlap. No `+1` conversion is required.
+
+### Pass the gate
+
+```bash
+cargo test --all-features every_primitive_integer_type_matches_forward_brute_force
+cargo test --all-features signed_seek_saturates_at_the_coordinate_minimum
+cargo test --all-features signed_depth_crosses_zero_once
+```
+
+## Checkpoint 15: remove only proven bounds checks
+
+Finish the safe implementation first and inspect its optimized assembly. The
+SIMD helpers already use pointer loads; they do not retain a Rust slice check per
+vector lane. The remaining useful reduction was private sidecar indexing in the
+block loop.
+
+The proof boundary is:
+
+```rust
+let block_start = self.next_block_start;
+if block_start >= self.inner.starts.len() {
+    return None;
+}
+```
+
+After construction or supported mutation, private invariants prove:
+
+```text
+stops_by_start.len() == starts.len()
+each metadata vector has ceil(starts.len() / 32) entries
+block = block_start / 32 names the metadata for this boundary
+block_end is clamped to starts.len()
+```
+
+Only then replace repeated private accesses:
+
+```rust
+let first_start = unsafe {
+    *self.inner.starts.get_unchecked(block_start)
+};
+let max_end = unsafe {
+    *self.inner.block_max_ends.get_unchecked(block)
+};
+let starts = unsafe {
+    self.inner.starts.get_unchecked(block_start..block_end)
+};
+```
+
+Keep returned interval indexing safe:
+
+```rust
+return Some(&self.inner.intervals[index]);
+```
+
+The public `intervals` vector could be edited directly, which has always made
+derived metadata stale. Bounding unsafe traversal by the private `starts.len()`
+prevents direct growth from extending unchecked sidecars; safe result indexing
+turns direct shrinkage into a possible panic rather than unchecked result access.
+
+### Invariant
+
+Every unsafe access must cite a private length relation established by
+`rebuild_derived()`. "The benchmark did not crash" is not a safety proof.
+
+### Work it by hand
+
+If `starts.len() = 65`, metadata length is `ceil(65 / 32) = 3`. Valid block
+starts are 0, 32, and 64; their block numbers are 0, 1, and 2. The final
+`block_end` is `min(96, 65) = 65`, so the final SIMD slice has one lane.
+
+### Pass the gate
+
+```bash
+cargo test --all-features
+cargo clippy --all-targets --all-features -- -D warnings
+git diff contender/simd-mask-narrow8-unchecked-index -- src/lib.rs
+```
+
+The measured specialized AArch64 function fell from 442 to 382 static
+instructions and from nine bounds-panic edges to two. Making result yields
+unchecked reached 363/zero but improved only about 0.3-0.6%, so that broader
+unsafe surface was rejected.
+
+## Final trace: run the complete search in your head
+
+Use the toy blocks from checkpoint 3 and query `[23, 28)`.
+
+1. Prefix maxima `[30, 30, 60]` return block 0 as the first possible block.
+2. Block 0 has `min=4`, `max=30`, so it is mixed.
+3. Its mask is `0b0010`; the iterator saves it.
+4. `next()` drains lane 1 and returns canonical interval `[2,30)`.
+5. The mask is empty, so the iterator enters block 1.
+6. Block 1 has `max=21 <= 23`; its next-greater link jumps to block 2.
+7. Block 2 has `min=25 > 23`; every end passes.
+8. The start prefix below query stop 28 contains lanes 0, 1, and 2.
+9. Three later `next()` calls return `[22,60)`, `[24,25)`, and `[27,35)`.
+10. Lane 3 starts at 40, so the globally sorted starts prove the query is done.
+
+The returned canonical indices are `[1, 8, 9, 10]`. That single trace exercises
+the mixed mask, saved iterator state, forward block skip, dense prefix, and global
+right-hand stopping proof.
+
+## The query algorithms side by side
+
+The sidecars support three distinct public query shapes:
+
+| API | Entry strategy | Result strategy |
+|---|---|---|
+| `find(start, stop)` | Binary-search `block_prefix_max_ends` | Lazily enumerate borrowed intervals through block routes |
+| `seek(start, stop, cursor)` | Reuse a monotonic-query cursor, bounded by `max_len`, then round down to its block | Use the same lazy block iterator as `find()` |
+| `count(start, stop)` | Binary-search global `starts` and global `stops` | Subtract the two excluded endpoint populations without enumeration |
+
+`find()` answers arbitrary queries independently. `seek()` is the same overlap
+problem with an extra promise from the caller: query starts arrive in sorted
+order, so a cursor can avoid repeating the entry binary search. It still returns
+the same references in the same order.
+
+`count()` uses a different identity because it does not need interval values:
+
+```text
+starts_before_query_stop       = number of interval starts < query_stop
+ends_at_or_before_query_start  = number of interval stops <= query_start
+
+overlap_count = starts_before_query_stop - ends_at_or_before_query_start
+```
+
+For a valid half-open query, every interval in the second population is also in
+the first, so the subtraction is nonnegative. `union_and_intersect()` and
+`depth()` compose the enumerating APIs; they do not introduce another overlap
+index.
+
+## The final data structure at a glance
+
+| State | Order | Purpose |
+|---|---|---|
+| `intervals` | `(start, stop)` | Canonical storage and returned references |
+| `starts` | Same as `intervals` | Prefix searches, stopping, SIMD starts |
+| `stops` | Globally sorted | `count()` binary search |
+| `stops_by_start` | Same as `intervals` | SIMD ends paired with lanes |
+| `block_max_ends` | One per 32 | Prove an all-miss block |
+| `block_min_ends` | One per 32 | Prove every end passes |
+| `block_index` | One per 32 | First later block with greater max end |
+| `block_prefix_max_ends` | Running max | Binary-search first possible block |
+| `max_len` | Scalar | Conservative cursor movement in `seek()` |
+
+Complexity is:
+
+```text
+build:  O(n log n) sorting + O(n) sidecar construction
+space:  O(n) coordinate sidecars + O(n / 32) block metadata
+count:  O(log n)
+find:   O(log blocks) entry search + candidate block work + output count
+seek:   cursor reuse for sorted queries + the same block iterator
+```
+
+## Why this remains Lapper-shaped
+
+The final index does not decompose intervals into containment-derived lists like
+AIList, build an NCList containment hierarchy, follow SuperIntervals'
+previous-greater links backward, or reorder nodes into a tree. It retains one
+canonical start-sorted vector, fixed positional block summaries, forward links,
+and a query-local mask drained low bit first.
+
+Maximum-end summaries, monotonic stacks, binary search, and SIMD comparison are
+general techniques. The structure's identity comes from how they are composed
+and from the preserved forward iterator contract.
+
+## Final comprehension checkpoint
+
+Do not look at the answers above while explaining these aloud:
+
+1. Why is `end == query_start` a miss?
+2. What does a next-greater link prove about every skipped entry?
+3. Why did per-interval links become 32-entry block links?
+4. Why is a prefix maximum needed in addition to each block maximum?
+5. Why does the dense route still need an active start prefix?
+6. Why does the mixed route not need a separate active prefix?
+7. Why must `stops` and `stops_by_start` both exist?
+8. Why does clearing the lowest set bit preserve forward order?
+9. Why is the weighted horizontal sum a mask rather than a count?
+10. Why is narrowing all-ones truth from `u32` to `u16` lossless?
+11. Why must `seek()` round its cursor down to a block boundary?
+12. What makes CPU dispatch different from a workload mode switch?
+13. Which invariant makes each `get_unchecked` access valid?
+14. Why are returned intervals still safely indexed?
+15. Which arrays must change after one insertion, and why is rebuilding simpler?
+
+Once you can answer all fifteen comprehension questions and reproduce the final
+toy trace, read
+[`PORTABLE_SIMD_INDEX.md`](PORTABLE_SIMD_INDEX.md) for the engineering summary
+and compare your complete practice worktree with
+`worked/portable-simd-index`.

--- a/AARCH64_U32_HAND_TYPE.md
+++ b/AARCH64_U32_HAND_TYPE.md
@@ -1,0 +1,203 @@
+# Hand-type the AArch64 `u32` mask path
+
+This is a deliberately narrow exercise: add the forward-order AArch64 NEON mask
+to the preserved 32-block rust-lapper prototype. The answer branch avoids generic
+type dispatch, x86, mutation rebuilding, and unchecked indexing so each machine-
+level idea is visible once.
+
+## Set up the exercise
+
+Create your own branch from the exact 32-block source:
+
+```bash
+git switch contender/block-32
+git switch -c practice/aarch64-u32-mask
+```
+
+Use the tutorial branch only as the answer key:
+
+```bash
+git diff tutorial/aarch64-u32-hand-typed -- src/lib.rs tests/block_index.rs
+```
+
+Run this checkpoint after every stage:
+
+```bash
+cargo test --test block_index
+```
+
+The test checks the count, the exact interval references, and forward order
+against brute force over randomized inputs.
+
+## 1. Store ends in start order
+
+The canonical interval vector and `starts` already share start order. Add one
+sidecar that preserves each interval's stop in that same order:
+
+```rust
+stops_by_start: Vec<I>,
+```
+
+Build it before sorting the separate `stops` vector used by `count()`:
+
+```rust
+let (starts, mut stops): (Vec<_>, Vec<_>) =
+    intervals.iter().map(|x| (x.start, x.stop)).unzip();
+let stops_by_start = stops.clone();
+```
+
+Why: a SIMD lane must load the start and stop for the same interval. The sorted
+`stops` array cannot provide that pairing.
+
+## 2. Add exact block facts
+
+For every 32-entry block, retain both its minimum and maximum stop. Also build a
+prefix maximum over block maxima.
+
+The three facts have separate jobs:
+
+```text
+max_end <= query.start  -> every lane misses; follow the skip link
+min_end > query.start   -> every active lane's end passes
+otherwise               -> the block is mixed; calculate a mask
+prefix_max <= start     -> binary-search directly to the first possible block
+```
+
+These are proofs, not a workload score.
+
+## 3. Give the iterator memory
+
+Add state for one query-local answer:
+
+```rust
+mask_block_start: usize,
+mask: u32,
+dense_next: usize,
+dense_end: usize,
+```
+
+At the top of `next()`, drain a dense prefix first, then a saved mask:
+
+```rust
+if self.mask != 0 {
+    let lane = self.mask.trailing_zeros() as usize;
+    self.mask &= self.mask - 1;
+    return Some(&self.inner.intervals[self.mask_block_start + lane]);
+}
+```
+
+`trailing_zeros()` selects the lowest lane. `mask & (mask - 1)` erases that lane.
+Those two operations are the forward-order contract.
+
+## 4. Make a scalar mask before using NEON
+
+Write and test this version first:
+
+```rust
+fn overlap_mask(
+    starts: &[u32],
+    stops: &[u32],
+    query_start: u32,
+    query_stop: u32,
+) -> u32 {
+    let mut mask = 0;
+    for lane in 0..starts.len() {
+        if stops[lane] > query_start && starts[lane] < query_stop {
+            mask |= 1 << lane;
+        }
+    }
+    mask
+}
+```
+
+Do not move on until the randomized test passes. SIMD must be only another way to
+compute this exact integer.
+
+## 5. Type one four-lane NEON comparison
+
+On AArch64, one 128-bit register holds four `u32` lanes:
+
+```rust
+let lane_starts = vld1q_u32(starts.as_ptr().add(lane));
+let lane_stops = vld1q_u32(stops.as_ptr().add(lane));
+
+let overlapping = vandq_u32(
+    vcgtq_u32(lane_stops, query_start_v),
+    vcgtq_u32(query_stop_v, lane_starts),
+);
+```
+
+Read the comparisons literally:
+
+```text
+interval.stop > query.start
+query.stop > interval.start
+```
+
+Each true lane is `0xffff_ffff`; each false lane is zero.
+
+## 6. Turn four truth lanes into four bits
+
+Type the weighted reduction once:
+
+```rust
+let weights = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
+let bits = vaddvq_u32(vandq_u32(overlapping, weights));
+mask |= bits << lane;
+```
+
+A true lane keeps its weight and a false lane keeps zero. Adding
+`[1, 0, 4, 8]` gives `13`, whose binary representation is `1101`. The sum is the
+mask; it is not a count.
+
+## 7. Load and pack eight lanes
+
+Replace two four-lane iterations with one paired load:
+
+```rust
+let lane_starts = vld1q_u32_x2(starts.as_ptr().add(lane));
+let lane_stops = vld1q_u32_x2(stops.as_ptr().add(lane));
+```
+
+Compare `.0` and `.1` independently. Then narrow and join their all-ones/all-zero
+answers:
+
+```rust
+let overlapping = vcombine_u16(
+    vmovn_u32(overlapping0),
+    vmovn_u32(overlapping1),
+);
+let weights = vld1q_u16(
+    [1_u16, 2, 4, 8, 16, 32, 64, 128].as_ptr(),
+);
+let bits = vaddvq_u16(vandq_u16(overlapping, weights));
+mask |= u32::from(bits) << lane;
+```
+
+Narrowing does not lose truth: the low 16 bits of all ones are still all ones.
+This lets one `addv.8h` produce eight bits instead of two `addv.4s` reductions.
+
+Keep the four-lane loop for a partial final block, and keep a scalar tail for a
+length not divisible by four.
+
+## 8. Inspect what the compiler made
+
+Ask rustc to retain assembly for the release library:
+
+```bash
+RUSTFLAGS='-C target-cpu=native' \
+  cargo rustc --release --lib -- --emit=asm
+rg -n 'ldp|uzp1|addv' target/release/deps/rust_lapper-*.s
+```
+
+The measured Apple M3 path contains paired `ldp` vector loads, `uzp1.8h`, and
+`addv.8h`. Handwritten assembly is unnecessary for this core.
+
+## Stop here once
+
+At this point you have typed every important ARM operation and can compare the
+whole answer against `tutorial/aarch64-u32-hand-typed`. The production-oriented
+`worked/portable-simd-index` branch deliberately moves type dispatch, mutation
+rebuilding, x86 AVX2, scalar fallback, and audited `get_unchecked` calls into
+separate helpers. Those abstractions are useful after the mechanics are familiar;
+they are noise during this first pass.

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -1,4 +1,4 @@
-# SIMD block mask with paired loads and eight-lane reduction
+# SIMD block mask with proof-scoped unchecked indexing
 
 This branch builds on the first exact SIMD-mask finalist. It keeps the
 32-interval block index, start-order end storage, block minima, and
@@ -34,6 +34,26 @@ execution order and using two unreported warmups per sample:
 
 Both binaries were built with `-C target-cpu=native`. The eight-lane reduction
 improved the paired median in all three cases.
+
+This branch additionally removes redundant bounds checks for block metadata and
+the two input slices after checking `block_start < intervals.len()`. Construction
+keeps all sidecars at the same length, each block number is derived from a valid
+32-entry boundary, and `block_end` is clamped to the interval length. Result
+yields remain safely indexed.
+
+The inlined AArch64 query function falls from 442 to 382 static instructions and
+from nine bounds-panic edges to two. Fifteen alternating-order pairs against the
+safe eight-lane branch measured:
+
+| Case | Safe query | Unchecked-index query | Paired median change | Faster pairs |
+|---|---:|---:|---:|---:|
+| `1-2` | 3.251 ms | 3.008 ms | -7.7% | 15/15 |
+| `7-3` | 47.459 ms | 43.504 ms | -8.1% | 15/15 |
+| `8-7` | 573.038 ms | 566.117 ms | -1.0% | 10/15 |
+
+In a fresh five-library run this version beat SuperIntervals in total time on
+`1-2` (6.026 vs 6.129 ms) and `7-3` (66.783 vs 67.951 ms), and trailed on dense
+`8-7` (579.622 vs 548.992 ms).
 
 For 1,956,864 intervals, the extra `u32` start-order ends cost about 7.47 MiB
 and block minima cost about 0.23 MiB. Metadata must be rebuilt after mutation

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -1,8 +1,13 @@
-# Always-on SIMD block-mask contender
+# SIMD block mask with weighted lane reduction
 
-This branch archives the first exact SIMD-mask finalist. It keeps the
-32-interval block index and adds start-order end storage, minimum ends per
-block, and `Lapper<u32, T>::find_block_mask`.
+This branch builds on the first exact SIMD-mask finalist. It keeps the
+32-interval block index, start-order end storage, block minima, and
+`Lapper<u32, T>::find_block_mask`.
+
+The new change is deliberately small: each four-lane NEON result is ANDed with
+bit weights `[1, 2, 4, 8]` and reduced with `vaddvq_u32`. This replaces four
+lane extractions plus their scalar shifts and ORs with one horizontal sum and
+one scalar shift/OR.
 
 Every candidate block takes one exact route:
 
@@ -16,13 +21,13 @@ There is no score, sampling heuristic, data classifier, or query mode switch.
 The scalar fallback is correct but was not performance-tested. The measured
 SIMD path is specialized to `u32` on AArch64.
 
-Recorded nine-repeat medians from one direct comparison session:
+Seven-repeat same-session means against the original mask prototype:
 
-| Case | Build | Query | Total |
+| Case | Original mask query | Weighted query | Change |
 |---|---:|---:|---:|
-| `1-2` | 3.231 ms | 4.100 ms | 7.295 ms |
-| `7-3` | 26.764 ms | 55.286 ms | 82.012 ms |
-| `8-7` | 36.926 ms | 603.311 ms | 640.183 ms |
+| `1-2` | 4.126 ms | 3.551 ms | -13.9% |
+| `7-3` | 55.261 ms | 49.575 ms | -10.3% |
+| `8-7` | 604.449 ms | 567.982 ms | -6.0% |
 
 For 1,956,864 intervals, the extra `u32` start-order ends cost about 7.47 MiB
 and block minima cost about 0.23 MiB. Metadata must be rebuilt after mutation

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -1,14 +1,15 @@
-# SIMD block mask with weighted lane reduction and paired loads
+# SIMD block mask with paired loads and eight-lane reduction
 
 This branch builds on the first exact SIMD-mask finalist. It keeps the
 32-interval block index, start-order end storage, block minima, and
 `Lapper<u32, T>::find_block_mask`.
 
-The weighted reduction remains unchanged: each four-lane NEON result is ANDed
-with bit weights `[1, 2, 4, 8]` and reduced with `vaddvq_u32`. The follow-up
-uses `vld1q_u32_x2` to load eight adjacent starts or stops into two registers
-per iteration. This lets AArch64 select a multi-register `LD1` form while the
-same two four-lane masks are assembled in forward order.
+The loop uses `vld1q_u32_x2` to load eight adjacent starts or stops into two
+registers per iteration. It narrows the two four-lane comparison vectors into
+eight `u16` lanes, ANDs them with weights `[1, 2, 4, 8, 16, 32, 64, 128]`, and
+uses one `vaddvq_u16` reduction to produce eight mask bits. On the measured
+Apple M3 binary this compiles to paired `ldp` loads, one `uzp1.8h`, and one
+`addv.8h` per eight lanes.
 
 Every candidate block takes one exact route:
 
@@ -22,16 +23,16 @@ There is no score, sampling heuristic, data classifier, or query mode switch.
 The scalar fallback is correct but was not performance-tested. The measured
 SIMD path is specialized to `u32` on AArch64.
 
-Fifteen paired trials against the weighted single-load version, alternating
+Fifteen paired trials against the paired-load, two-reduction version, alternating
 execution order and using two unreported warmups per sample:
 
-| Case | Single-load query | Paired-load query | Paired median change |
-|---|---:|---:|---:|
-| `1-2` | 3.595 ms | 3.443 ms | -4.6% |
-| `7-3` | 51.008 ms | 49.410 ms | -3.1% |
+| Case | Two reductions | Eight-lane reduction | Paired median change | Faster pairs |
+|---|---:|---:|---:|---:|
+| `1-2` | 3.614 ms | 3.482 ms | -3.2% | 12/15 |
+| `7-3` | 49.464 ms | 48.376 ms | -2.1% | 14/15 |
+| `8-7` | 586.479 ms | 586.697 ms | -0.02% | 8/15 |
 
-A separate nine-repeat dense run measured 579.273 ms for the single-load
-version and 579.313 ms for paired loads, which is neutral.
+The dense result is effectively neutral rather than evidence of a speedup.
 
 For 1,956,864 intervals, the extra `u32` start-order ends cost about 7.47 MiB
 and block minima cost about 0.23 MiB. Metadata must be rebuilt after mutation

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -46,6 +46,7 @@ instruction-audited but not timed on native Intel or AMD hardware.
 
 See [`PORTABLE_SIMD_INDEX.md`](PORTABLE_SIMD_INDEX.md) for the full design,
 safety argument, compatibility notes, tests, measurements, and identity audit.
-For the intentionally narrow first ARM exercise, compare
-`contender/block-32` with `tutorial/aarch64-u32-hand-typed` using
-[`AARCH64_U32_HAND_TYPE.md`](AARCH64_U32_HAND_TYPE.md) on the tutorial branch.
+Use [`AARCH64_U32_HAND_TYPE.md`](AARCH64_U32_HAND_TYPE.md) on this branch as the
+single hand-typing course from original scalar Lapper through the full portable
+implementation. At its ARM checkpoints, the intentionally narrow answer code is
+the diff from `contender/block-32` to `tutorial/aarch64-u32-hand-typed`.

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -1,25 +1,29 @@
-# Always-on 32-interval block contender
+# Always-on SIMD block-mask contender
 
-This branch is an exact archive of the live `feat/index` working-tree source at
-the start of the SIMD experiments. The source hash was:
+This branch archives the first exact SIMD-mask finalist. It keeps the
+32-interval block index and adds start-order end storage, minimum ends per
+block, and `Lapper<u32, T>::find_block_mask`.
 
-```text
-ece99b9751f9aecbcdd6758415690072901ca4934d16dacfd703fcf7b7eef0ee  src/lib.rs
-```
+Every candidate block takes one exact route:
 
-It stores maximum ends, next-greater links, and monotonic prefix maxima for
-fixed 32-interval blocks. The prefix maxima choose the first candidate block;
-the block links skip later all-miss blocks. Both optimizations are always on,
-and `find` still yields references in ascending start order.
+1. `max_end <= query.start`: jump over the all-miss block.
+2. `min_end > query.start`: all active lanes pass the end test, so return the
+   sorted-start prefix directly.
+3. Otherwise: calculate one NEON overlap mask, save it in the iterator, and
+   consume its low set bits in forward order across `next()` calls.
 
-Recorded nine-repeat medians from the same direct harness used for the SIMD
-comparison:
+There is no score, sampling heuristic, data classifier, or query mode switch.
+The scalar fallback is correct but was not performance-tested. The measured
+SIMD path is specialized to `u32` on AArch64.
+
+Recorded nine-repeat medians from one direct comparison session:
 
 | Case | Build | Query | Total |
 |---|---:|---:|---:|
-| `1-2` | 3.263 ms | 5.875 ms | 9.124 ms |
-| `7-3` | 26.742 ms | 87.010 ms | 113.716 ms |
-| `8-7` | 36.949 ms | 608.013 ms | 644.990 ms |
+| `1-2` | 3.231 ms | 4.100 ms | 7.295 ms |
+| `7-3` | 26.764 ms | 55.286 ms | 82.012 ms |
+| `8-7` | 36.926 ms | 603.311 ms | 640.183 ms |
 
-The archived mutation caveat still applies: block metadata must be rebuilt
-after `insert` and `merge_overlaps` before production integration.
+For 1,956,864 intervals, the extra `u32` start-order ends cost about 7.47 MiB
+and block minima cost about 0.23 MiB. Metadata must be rebuilt after mutation
+before production integration.

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -1,60 +1,51 @@
-# SIMD block mask with proof-scoped unchecked indexing
+# Worked portable SIMD block index
 
-This branch builds on the first exact SIMD-mask finalist. It keeps the
-32-interval block index, start-order end storage, block minima, and
-`Lapper<u32, T>::find_block_mask`.
+This branch integrates the best forward-order contender into rust-lapper's
+normal API. `find()` and `seek()` retain their existing signatures and lazy,
+ascending-start output. There is no workload score, data classifier, mode flag,
+or alternate public query method.
 
-The loop uses `vld1q_u32_x2` to load eight adjacent starts or stops into two
-registers per iteration. It narrows the two four-lane comparison vectors into
-eight `u16` lanes, ANDs them with weights `[1, 2, 4, 8, 16, 32, 64, 128]`, and
-uses one `vaddvq_u16` reduction to produce eight mask bits. On the measured
-Apple M3 binary this compiles to paired `ldp` loads, one `uzp1.8h`, and one
-`addv.8h` per eight lanes.
+The implementation keeps one canonical start-sorted interval vector and adds
+fixed 32-entry block facts:
 
-Every candidate block takes one exact route:
+- a maximum end and a next-greater-block link for exact forward skips;
+- a minimum end for an exact all-ends-pass route;
+- a prefix maximum for finding the first possible block;
+- ends in start order for mixed-block masks.
 
-1. `max_end <= query.start`: jump over the all-miss block.
-2. `min_end > query.start`: all active lanes pass the end test, so return the
-   sorted-start prefix directly.
-3. Otherwise: calculate one NEON overlap mask, save it in the iterator, and
-   consume its low set bits in forward order across `next()` calls.
+Mixed blocks use NEON on AArch64, AVX2 when available on x86-64, and an exact
+scalar fallback elsewhere. The SIMD dispatch covers all primitive integer
+coordinate types from 8 through 64 bits, including `usize` and `isize`.
+Custom `PrimInt` implementations use the scalar mask.
 
-There is no score, sampling heuristic, data classifier, or query mode switch.
-The scalar fallback is correct but was not performance-tested. The measured
-SIMD path is specialized to `u32` on AArch64.
+`insert()`, `merge_overlaps()`, construction, and serde deserialization all run
+the same derived-index rebuild. Signed coordinates, minimum-value queries,
+`count()` at a type maximum, and depth spans crossing zero have dedicated tests.
+Serde keeps the original six-field representation and reconstructs the new
+private sidecars when reading it.
 
-Fifteen paired trials against the paired-load, two-reduction version, alternating
-execution order and using two unreported warmups per sample:
+The hot loop uses `get_unchecked` only after a length invariant has proved the
+private sidecars cover the candidate block. Returned intervals remain safely
+indexed. The assembly audit found no reason to add handwritten assembly: the
+AArch64 compiler output already contains paired loads, narrowing, and horizontal
+reduction, while forced-Haswell output contains the expected AVX2 compares and
+movemask instructions.
 
-| Case | Two reductions | Eight-lane reduction | Paired median change | Faster pairs |
-|---|---:|---:|---:|---:|
-| `1-2` | 3.380 ms | 3.221 ms | -4.4% | 15/15 |
-| `7-3` | 48.212 ms | 47.225 ms | -2.6% | 13/15 |
-| `8-7` | 573.589 ms | 570.430 ms | -1.1% | 13/15 |
+Fresh native five-library total medians:
 
-Both binaries were built with `-C target-cpu=native`. The eight-lane reduction
-improved the paired median in all three cases.
+| Case | SuperIntervals | Worked Lapper | COITrees | rust-bio IITree | rust-bio AVL |
+|---|---:|---:|---:|---:|---:|
+| `1-2` | 6.063 ms | **5.729 ms** | 10.415 ms | 13.311 ms | 42.062 ms |
+| `7-3` | 68.881 ms | **66.385 ms** | 89.782 ms | 149.975 ms | 344.913 ms |
+| `8-7` | **550.372 ms** | 588.766 ms | 834.219 ms | 1259.076 ms | 2140.363 ms |
 
-This branch additionally removes redundant bounds checks for block metadata and
-the two input slices after checking `block_start < intervals.len()`. Construction
-keeps all sidecars at the same length, each block number is derived from a valid
-32-entry boundary, and `block_end` is clamped to the interval length. Result
-yields remain safely indexed.
+Alternating direct trials confirmed the shape: Lapper won total time on 15/15
+`1-2` pairs, was 1.76% faster on `7-3`, and trailed by about 9.5% total on
+dense `8-7`. These are Apple M3 AArch64 measurements; AVX2 was compiled and
+instruction-audited but not timed on native Intel or AMD hardware.
 
-The inlined AArch64 query function falls from 442 to 382 static instructions and
-from nine bounds-panic edges to two. Fifteen alternating-order pairs against the
-safe eight-lane branch measured:
-
-| Case | Safe query | Unchecked-index query | Paired median change | Faster pairs |
-|---|---:|---:|---:|---:|
-| `1-2` | 3.251 ms | 3.008 ms | -7.7% | 15/15 |
-| `7-3` | 47.459 ms | 43.504 ms | -8.1% | 15/15 |
-| `8-7` | 573.038 ms | 566.117 ms | -1.0% | 10/15 |
-
-In a fresh five-library run this version beat SuperIntervals in total time on
-`1-2` (6.026 vs 6.129 ms) and `7-3` (66.783 vs 67.951 ms), and trailed on dense
-`8-7` (579.622 vs 548.992 ms).
-
-For 1,956,864 intervals, the extra `u32` start-order ends cost about 7.47 MiB
-and block minima cost about 0.23 MiB. Metadata must be rebuilt after mutation
-before production integration.
+See [`PORTABLE_SIMD_INDEX.md`](PORTABLE_SIMD_INDEX.md) for the full design,
+safety argument, compatibility notes, tests, measurements, and identity audit.
+For the intentionally narrow first ARM exercise, compare
+`contender/block-32` with `tutorial/aarch64-u32-hand-typed` using
+[`AARCH64_U32_HAND_TYPE.md`](AARCH64_U32_HAND_TYPE.md) on the tutorial branch.

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -1,13 +1,14 @@
-# SIMD block mask with weighted lane reduction
+# SIMD block mask with weighted lane reduction and paired loads
 
 This branch builds on the first exact SIMD-mask finalist. It keeps the
 32-interval block index, start-order end storage, block minima, and
 `Lapper<u32, T>::find_block_mask`.
 
-The new change is deliberately small: each four-lane NEON result is ANDed with
-bit weights `[1, 2, 4, 8]` and reduced with `vaddvq_u32`. This replaces four
-lane extractions plus their scalar shifts and ORs with one horizontal sum and
-one scalar shift/OR.
+The weighted reduction remains unchanged: each four-lane NEON result is ANDed
+with bit weights `[1, 2, 4, 8]` and reduced with `vaddvq_u32`. The follow-up
+uses `vld1q_u32_x2` to load eight adjacent starts or stops into two registers
+per iteration. This lets AArch64 select a multi-register `LD1` form while the
+same two four-lane masks are assembled in forward order.
 
 Every candidate block takes one exact route:
 
@@ -21,13 +22,16 @@ There is no score, sampling heuristic, data classifier, or query mode switch.
 The scalar fallback is correct but was not performance-tested. The measured
 SIMD path is specialized to `u32` on AArch64.
 
-Seven-repeat same-session means against the original mask prototype:
+Fifteen paired trials against the weighted single-load version, alternating
+execution order and using two unreported warmups per sample:
 
-| Case | Original mask query | Weighted query | Change |
+| Case | Single-load query | Paired-load query | Paired median change |
 |---|---:|---:|---:|
-| `1-2` | 4.126 ms | 3.551 ms | -13.9% |
-| `7-3` | 55.261 ms | 49.575 ms | -10.3% |
-| `8-7` | 604.449 ms | 567.982 ms | -6.0% |
+| `1-2` | 3.595 ms | 3.443 ms | -4.6% |
+| `7-3` | 51.008 ms | 49.410 ms | -3.1% |
+
+A separate nine-repeat dense run measured 579.273 ms for the single-load
+version and 579.313 ms for paired loads, which is neutral.
 
 For 1,956,864 intervals, the extra `u32` start-order ends cost about 7.47 MiB
 and block minima cost about 0.23 MiB. Metadata must be rebuilt after mutation

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -28,11 +28,12 @@ execution order and using two unreported warmups per sample:
 
 | Case | Two reductions | Eight-lane reduction | Paired median change | Faster pairs |
 |---|---:|---:|---:|---:|
-| `1-2` | 3.614 ms | 3.482 ms | -3.2% | 12/15 |
-| `7-3` | 49.464 ms | 48.376 ms | -2.1% | 14/15 |
-| `8-7` | 586.479 ms | 586.697 ms | -0.02% | 8/15 |
+| `1-2` | 3.380 ms | 3.221 ms | -4.4% | 15/15 |
+| `7-3` | 48.212 ms | 47.225 ms | -2.6% | 13/15 |
+| `8-7` | 573.589 ms | 570.430 ms | -1.1% | 13/15 |
 
-The dense result is effectively neutral rather than evidence of a speedup.
+Both binaries were built with `-C target-cpu=native`. The eight-lane reduction
+improved the paired median in all three cases.
 
 For 1,956,864 intervals, the extra `u32` start-order ends cost about 7.47 MiB
 and block minima cost about 0.23 MiB. Metadata must be rebuilt after mutation

--- a/CONTENDER.md
+++ b/CONTENDER.md
@@ -1,0 +1,25 @@
+# Always-on 32-interval block contender
+
+This branch is an exact archive of the live `feat/index` working-tree source at
+the start of the SIMD experiments. The source hash was:
+
+```text
+ece99b9751f9aecbcdd6758415690072901ca4934d16dacfd703fcf7b7eef0ee  src/lib.rs
+```
+
+It stores maximum ends, next-greater links, and monotonic prefix maxima for
+fixed 32-interval blocks. The prefix maxima choose the first candidate block;
+the block links skip later all-miss blocks. Both optimizations are always on,
+and `find` still yields references in ascending start order.
+
+Recorded nine-repeat medians from the same direct harness used for the SIMD
+comparison:
+
+| Case | Build | Query | Total |
+|---|---:|---:|---:|
+| `1-2` | 3.263 ms | 5.875 ms | 9.124 ms |
+| `7-3` | 26.742 ms | 87.010 ms | 113.716 ms |
+| `8-7` | 36.949 ms | 608.013 ms | 644.990 ms |
+
+The archived mutation caveat still applies: block metadata must be rebuilt
+after `insert` and `merge_overlaps` before production integration.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust-lapper"
 version = "1.3.0"
 authors = ["Seth Stadick <sstadick@gmail.com>"]
 edition = "2018"
+rust-version = "1.59"
 license = "MIT"
 repository = "https://github.com/sstadick/rust-lapper"
 description = "A fast and easy interval overlap library"

--- a/PORTABLE_SIMD_INDEX.md
+++ b/PORTABLE_SIMD_INDEX.md
@@ -1,0 +1,392 @@
+# Portable forward-order SIMD index
+
+## Goal
+
+This branch takes the fastest retained rust-lapper contender and makes it a
+complete implementation rather than a benchmark-only `u32` experiment.
+
+The constraints are deliberate:
+
+- keep `Lapper::find()` and `Lapper::seek()` as the query API;
+- yield the same interval references in ascending start order;
+- use the same exact algorithm for every workload;
+- rebuild every derived array after supported mutation;
+- support signed and unsigned primitive coordinates from 8 through 64 bits;
+- accelerate AArch64 and x86-64 without making other targets incorrect; and
+- use `unsafe` only where a documented invariant removes measured hot-loop work.
+
+CPU feature dispatch is not a query mode. A query always follows the same block
+algorithm. Only the instruction sequence used to calculate an exact mixed-block
+mask changes with the CPU and coordinate type.
+
+## Public behavior
+
+The production path is the ordinary one:
+
+```rust
+for interval in lapper.find(query_start, query_stop) {
+    // Same borrowed Interval, same ascending-start order.
+}
+
+for interval in lapper.seek(query_start, query_stop, &mut cursor) {
+    // Same cursor-facing API.
+}
+```
+
+The experimental `find_block_mask()` method is gone. No mode setting or score is
+exposed. `Lapper`, `Interval`, `IterFind`, mutation methods, iterators, and serde
+field names remain available as before.
+
+The generic implementation now requires `I: 'static` so it can use `TypeId` to
+select only exact built-in integer representations before any SIMD pointer cast.
+This is invisible for all primitive coordinate types. It is a theoretical source
+compatibility constraint for an exotic lifetime-carrying custom `PrimInt`.
+
+## Derived layout
+
+The canonical `intervals` vector remains sorted by `(start, stop)`. The index does
+not reorder that vector. Construction derives:
+
+| Array | Length | Purpose |
+|---|---:|---|
+| `starts` | `n` | Start binary searches and SIMD input |
+| `stops` | `n` | Globally sorted ends for `count()` |
+| `stops_by_start` | `n` | End paired with each start for a mask lane |
+| `block_max_ends` | `ceil(n / 32)` | Prove a whole block misses |
+| `block_min_ends` | `ceil(n / 32)` | Prove every active lane's end passes |
+| `block_index` | `ceil(n / 32)` | Next block to the right with a greater maximum end |
+| `block_prefix_max_ends` | `ceil(n / 32)` | Binary-search the first possible block |
+
+The block size remains 32. It maps one block result to one `u32` mask, amortizes
+metadata, and was the best compromise across the measured sparse and dense cases.
+Making SIMD lanes wider changes how quickly a mixed block is classified; it does
+not remove the metadata, output, and partial-block tradeoffs that made 64-entry
+blocks regress in an earlier trial.
+
+`block_index` is built with a reverse monotonic stack. If block `b` has
+`max_end <= query.start`, its link points to the first later block with a strictly
+greater maximum. Every skipped intermediate block has a maximum no greater than
+block `b`, so all of them are also exact misses.
+
+## One always-on traversal
+
+`find()` binary-searches `block_prefix_max_ends` to skip the leading prefix whose
+intervals all end at or before `query.start`. `seek()` retains its cursor behavior,
+then rounds the candidate position down to its containing 32-entry block. The
+normal block loop has three exact routes:
+
+```text
+block.max_end <= query.start
+    -> all 32 miss; follow the next-greater block link
+
+block.min_end > query.start
+    -> every end passes; return starts < query.stop as a dense prefix
+
+otherwise
+    -> starts and ends are mixed; calculate and save an exact overlap mask
+```
+
+Before any route, the first block start is compared with `query.stop`. Starts are
+globally sorted, so failure ends the iterator. In the dense route a partition
+point finds the active start prefix. In the mixed route the mask checks both
+half-open overlap predicates:
+
+```text
+interval.stop > query.start
+interval.start < query.stop
+```
+
+This removes the old active-prefix special case from the mixed path. SIMD checks
+the candidate slice that exists, including start failures; those lanes simply
+become zero.
+
+## Why order is unchanged
+
+The iterator stores one mixed-block mask. Each `next()` call removes its least
+significant set bit:
+
+```rust
+let lane = self.mask.trailing_zeros() as usize;
+self.mask &= self.mask - 1;
+return Some(&self.inner.intervals[self.mask_block_start + lane]);
+```
+
+The lowest bit is the lowest position in the start-sorted block. Blocks are only
+visited to the right, dense prefixes are walked from their first item, and skip
+links only point right. Therefore results remain references into the canonical
+vector in ascending start order. SIMD changes how a block answer is calculated,
+not the observable traversal identity.
+
+## SIMD backends and integer widths
+
+`src/simd.rs` owns one private operation:
+
+```rust
+overlap_mask(starts, stops, query_start, query_stop) -> u32
+```
+
+It always returns the same lane-to-bit mapping. Exact `TypeId` checks allow SIMD
+only for these built-ins:
+
+```text
+u8 i8 u16 i16 u32 i32 u64 i64 usize isize
+```
+
+Any other `PrimInt` takes the scalar implementation. Partial final vectors also
+use a small scalar tail.
+
+### AArch64 NEON
+
+NEON is part of baseline AArch64. Its registers are 128 bits, so one register has
+16 byte lanes, 8 halfword lanes, 4 word lanes, or 2 doubleword lanes. Paired
+loads process two adjacent registers when possible.
+
+| Coordinate | Values per paired load | Truth-to-bit packing |
+|---|---:|---|
+| `u8` / `i8` | 32 | two 16-lane weighted byte reductions |
+| `u16` / `i16` | 16 | narrow to bytes, then weighted reduction |
+| `u32` / `i32` | 8 | narrow to halfwords, then one `addv.8h` |
+| `u64` / `i64` | 4 | narrow to words, then one weighted reduction |
+
+The central `u32` trick is:
+
+```rust
+let eight_truths = vcombine_u16(
+    vmovn_u32(overlaps_low),
+    vmovn_u32(overlaps_high),
+);
+let weights = vld1q_u16([1, 2, 4, 8, 16, 32, 64, 128].as_ptr());
+let bits = vaddvq_u16(vandq_u16(eight_truths, weights));
+```
+
+A comparison produces all ones for true and zero for false. Narrowing preserves
+that truth. AND keeps a lane's power-of-two weight only when it is true; the
+horizontal sum is therefore the bit mask, not a match count.
+
+### x86-64 AVX2
+
+Every iterator performs the standard runtime AVX2 feature check once. AVX2 uses
+256-bit registers and native movemask instructions:
+
+| Coordinate | Values per vector | Mask extraction |
+|---|---:|---|
+| `u8` / `i8` | 32 | `vpmovmskb` |
+| `u16` / `i16` | 16 | `vpmovmskb`, then compact duplicate byte bits |
+| `u32` / `i32` | 8 | `vmovmskps` on comparison bits |
+| `u64` / `i64` | 4 | `vmovmskpd` on comparison bits |
+
+AVX2 integer greater-than comparisons are signed. Unsigned inputs are XORed with
+their type's sign bit before comparing. That order-preserving transform maps the
+unsigned domain onto the signed domain without changing the overlap predicate.
+
+### Other CPUs and custom integers
+
+The scalar backend calculates the same `u32` mask lane by lane. This keeps the
+algorithm and output identical on targets such as `wasm32-wasip1` and on x86-64
+machines without AVX2. It is a correctness fallback, not a workload-dependent
+choice.
+
+SVE/SVE2 and AVX-512 are possible later backends, but are not present here. Their
+predicate/mask facilities could classify a 32-entry block in fewer vector groups.
+They need native hardware measurements before becoming a recommendation.
+
+## Mutation, construction, and serde
+
+All sidecars are derived state. `rebuild_derived()` is the single construction
+path and is called by:
+
+- `Lapper::new()`;
+- `insert()` after its sorted insertion;
+- `merge_overlaps()` after it replaces the interval vector; and
+- serde deserialization through `Lapper::new()`.
+
+The rebuild uses one bulk `unzip()` for starts and start-order stops, clones the
+stops once for global sorting, then builds block summaries. Restoring this bulk
+path recovered build time that an earlier incremental prototype had lost.
+
+With `with_serde`, serialization deliberately writes the original six fields:
+`intervals`, `starts`, `stops`, `max_len`, `cov`, and `overlaps_merged`. New
+private sidecars are not serialized. Deserialization treats `intervals` as the
+source of truth and rebuilds every sidecar, then restores the cached coverage and
+merge flag. Existing serialized shape therefore does not acquire architecture-
+or implementation-specific metadata.
+
+## Signed-coordinate corrections
+
+Generalizing beyond unsigned coordinates exposed three assumptions in the old
+code:
+
+- `seek()` now uses `checked_sub(max_len)` and falls back to `I::min_value()`;
+- `count()` uses `partition_point(stop <= start)` instead of forming `start + 1`,
+  which can overflow at the coordinate maximum; and
+- `depth()` has an explicit initialization flag instead of using zero as a
+  sentinel, so an interval spanning negative through positive coordinates begins
+  at its actual start.
+
+These are scalar correctness repairs needed by the wider type support; they are
+not query heuristics.
+
+## Bounds-check and unsafe audit
+
+Release assembly showed that the SIMD helpers already use pointer vector loads;
+there were no hidden per-lane Rust slice checks in the vector core. The remaining
+hot-loop checks were on private sidecar indexing.
+
+The accepted branch uses `get_unchecked` for those sidecars after one public
+invariant boundary:
+
+1. `block_start < starts.len()` is checked.
+2. Constructors, supported mutation, and deserialization rebuild `starts` and
+   `stops_by_start` to equal lengths.
+3. They also build one entry in every block metadata vector for each 32-entry
+   start block.
+4. `block_end` is clamped to `starts.len()`.
+5. A link is either a valid later block or the block-count sentinel.
+
+The block link is guarded by a debug assertion. Returned `intervals` remain
+safely indexed, so unsupported direct edits to the public vector can at worst
+produce stale behavior or a panic, not turn a result yield into unchecked memory
+access. Directly appending to `intervals` is ignored by the private derived bound;
+supported mutation must continue to use `insert()` or `merge_overlaps()`.
+
+For the specialized AArch64 query, this change reduced the inlined function from
+442 to 382 static instructions and bounds-panic edges from nine to two. Making
+the final result access unchecked reduced it further to 363/zero but improved
+queries by only about 0.3-0.6%, so that broader unsafe surface was rejected.
+
+Handwritten assembly was also rejected. LLVM already emits the intended AArch64
+`ldp`, `uzp1.8h`, and `addv.8h` sequence. A forced Haswell build contains
+`vpmovmskb`, `vmovmskps`, `vmovmskpd`, `vpcmpgt*`, `vpxor`, and `vpand`. Inline
+assembly would add review and register-allocation risk without removing a known
+instruction in these cores.
+
+The detailed audit is in the bakeoff's `ASSEMBLY_BOUNDS_AUDIT.md`.
+
+## Correctness and portability checks
+
+The branch passes:
+
+```text
+native cargo test --all-features
+native cargo clippy --all-targets --all-features -- -D warnings
+x86_64-apple-darwin cargo test --all-features --test portable_index
+x86_64-apple-darwin cargo check --all-features
+wasm32-wasip1 cargo clippy --lib --all-features -- -D warnings
+```
+
+Coverage includes:
+
+- randomized `find()`, `seek()`, and `count()` against brute force;
+- exact reference order for all ten primitive integer types;
+- negative intervals and a query at the signed minimum;
+- insert and merge rebuilding across more than four blocks;
+- serde round trips with derived metadata reconstruction;
+- signed depth across zero;
+- safety when the public interval vector is directly extended;
+- exhaustive AVX2 `u16` movemask compaction; and
+- forced calls to each AVX2 primitive function when AVX2 is available.
+
+The x86-64 test executable ran under Rosetta on the Apple host. Rosetta did not
+advertise AVX2, so the backend's instructions were verified in forced-Haswell
+assembly rather than performance-tested or executed there. Native Intel/AMD CI
+remains required before merging an x86 performance claim.
+
+## Performance record
+
+All times below are medians in milliseconds. The five-library worked run used
+the normal `find()` API and native Apple M3 compilation.
+
+| Case | SuperIntervals | Worked Lapper | COITrees | rust-bio IITree | rust-bio AVL |
+|---|---:|---:|---:|---:|---:|
+| `1-2` | 6.063 | **5.729** | 10.415 | 13.311 | 42.062 |
+| `7-3` | 68.881 | **66.385** | 89.782 | 149.975 | 344.913 |
+| `8-7` | **550.372** | 588.766 | 834.219 | 1259.076 | 2140.363 |
+
+Those totals combine independently reported build and query medians. Direct
+alternating Lapper/SuperIntervals process pairs give the more reliable close-call
+interpretation:
+
+| Case | Worked Lapper versus SuperIntervals total | Pair wins |
+|---|---:|---:|
+| `1-2` | -7.71% paired median | 15 / 15 |
+| `7-3` | -1.76% paired median | 12 / 15 |
+| `8-7` | +9.50% paired median | 0 / 10 |
+
+On `7-3`, Lapper's query remained about 13% slower but its cheaper build erased
+that difference for one build plus one query batch. On dense `8-7`, output work
+dominates and SuperIntervals retains a clear advantage.
+
+The worked generic integration stayed within about 1.3% of the specialized
+unchecked `u32` branch in paired query trials:
+
+| Case | Worked query change versus specialized | Worked wins |
+|---|---:|---:|
+| `1-2` | -2.14% | 11 / 15 |
+| `7-3` | +1.53% | 1 / 15 |
+| `8-7` | +1.31% | 2 / 10 |
+
+For orientation, the original v1.3.0 query medians were 5.648, 5049.867, and
+884.546 ms on `1-2`, `7-3`, and `8-7`. Those original-versus-worked values came
+from separate controlled runs and should not be read as paired microbenchmark
+percentages. Raw files and methods live under the bakeoff's
+`results/forward-simd-2026-07-18/` directory.
+
+## Why this is not AIList or another renamed index
+
+This conclusion is structural, not based on names such as "maximum end."
+
+| Implementation | Canonical layout | Index shape | Query direction / state |
+|---|---|---|---|
+| This Lapper | One vector sorted by start | Fixed positional block summaries and forward next-greater links | Forward blocks; query-local low-bit-first mask |
+| AIList | Intervals decomposed into multiple containment-derived lists | Per-list running maximum ends | Searches/scans each component backward |
+| NCList | Intervals organized by containment | Nested containment hierarchy | Hierarchical sublist traversal |
+| SuperIntervals | Separate starts, ends, payloads, and branch arrays | Previous-greater/equal end links | Begins near the query boundary and follows links backward |
+| COITrees | Augmented tree nodes in cache-oriented order | Centered interval tree | Tree traversal over augmented nodes |
+| rust-bio IITree / AVL | Tree-owned interval nodes | Interval-tree augmentation | Tree traversal |
+
+This branch does not perform AIList's containment decomposition, create component
+lists, or scan those lists backward. It does not build NCList's containment
+hierarchy. It does not use SuperIntervals' previous-greater link direction or
+separate canonical storage. It does not reorder the intervals into a tree.
+
+What is shared is general interval-index vocabulary: sorting endpoints, storing
+end extrema, skipping regions proved unable to overlap, and using SIMD to evaluate
+independent predicates. Those shared techniques do not make the data structures
+the same. This comparison is not a patent-clearance or exhaustive prior-art
+opinion.
+
+Primary references used for the structural check:
+
+- [AIList paper](https://pmc.ncbi.nlm.nih.gov/articles/PMC6901075/)
+- [AIList C construction and query](https://github.com/databio/AIList/blob/366fe0a6f5c77cdd165c1452f49adf0ecbbef4e6/src/AIList.c#L130-L317)
+- [gtars Rust AIList](https://github.com/databio/gtars/blob/cd75994966f039aa52d9359d64a3a201eee25de7/gtars-overlaprs/src/ailist.rs#L92-L375)
+- [SuperIntervals 0.3.6 source](https://github.com/biodatageeks/sequila-native/blob/745d40f77da7ced5d540f9285eb5123ba12682ff/sequila/sequila-core/superintervals/src/superintervals.rs)
+- [COITrees 0.4.0 non-SIMD source](https://github.com/dcjones/coitrees/blob/4afeeebe6e5d3229c2c191d5676ed71310d953e0/src/nosimd.rs)
+
+## Branch map
+
+| Branch | Commit | Purpose |
+|---|---|---|
+| `baseline/v1.3.0` | `c545d40` | Original rust-lapper release state |
+| `contender/per-interval` | `0af2d23` | Reconstructed next-greater index per interval |
+| `contender/block-32` | `559c183` | Preserved always-on 32-entry block index |
+| `contender/simd-mask-narrow8-ld1x2` | `84872e7` | Safe specialized AArch64 mask |
+| `contender/simd-mask-narrow8-unchecked-index` | `b6ba527` | Specialized best with audited unchecked sidecars |
+| `tutorial/aarch64-u32-hand-typed` | `dfc5f01` | Narrow answer key for typing the ARM path once |
+| `reference/aarch64-u32-hand-typed` | `b6ba527` | Exact full-reference comparison point |
+| `worked/portable-simd-index` | this branch | Mutation-safe, multi-type, multi-architecture integration |
+
+The tutorial starts from `contender/block-32` and intentionally excludes generic
+dispatch, AVX2, mutation rebuilding, and unchecked indexing. That keeps the first
+hand-typed ARM pass readable. The worked branch is the complete candidate, not the
+tutorial branch.
+
+## Remaining decisions
+
+- Measure AVX2 on native Intel and AMD hardware.
+- Add native big-endian and non-Apple AArch64 CI if those are support targets.
+- Measure memory/cache behavior across coordinate and payload widths.
+- Decide whether the theoretical new `I: 'static` constraint is acceptable.
+- Treat SVE2 and AVX-512 as separate CPU backends only after native evidence.
+- Preserve safe result indexing unless a new measurement justifies expanding the
+  unsafe proof.

--- a/PORTABLE_SIMD_INDEX.md
+++ b/PORTABLE_SIMD_INDEX.md
@@ -376,10 +376,12 @@ Primary references used for the structural check:
 | `reference/aarch64-u32-hand-typed` | `b6ba527` | Exact full-reference comparison point |
 | `worked/portable-simd-index` | this branch | Mutation-safe, multi-type, multi-architecture integration |
 
-The tutorial starts from `contender/block-32` and intentionally excludes generic
-dispatch, AVX2, mutation rebuilding, and unchecked indexing. That keeps the first
-hand-typed ARM pass readable. The worked branch is the complete candidate, not the
-tutorial branch.
+The unified [`AARCH64_U32_HAND_TYPE.md`](AARCH64_U32_HAND_TYPE.md) course starts
+at `baseline/v1.3.0` and walks through every index and SIMD checkpoint. The
+`tutorial/aarch64-u32-hand-typed` branch remains a deliberately narrow code
+answer for the ARM portion: it excludes generic dispatch, AVX2, mutation
+rebuilding, and unchecked indexing so those operations can be learned once
+without production scaffolding.
 
 ## Remaining decisions
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ algorithm](https://academic.oup.com/bioinformatics/article/29/1/1/273289)
 `rust-lapper` supports Rust 1.59 and newer. Rust 1.59 is the first stable
 release that provides the AArch64 intrinsics used by the NEON query backend.
 
+Query coordinates must be `'static` so private dispatch code can use `TypeId`
+before reinterpreting primitive integer slices for SIMD. This includes every
+primitive integer and ordinary owned custom numeric type; it does not require a
+`Lapper` value to live for the entire program. Non-primitive `PrimInt` types use
+the scalar mask implementation.
+
 ## Serde Support
 
 `rust-lapper` supports serialization with serde for `Lapper` and `Interval` objects:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ type, and should be about as fast as it is possible to be on any
 dataset. It is an implementation of the [BITS
 algorithm](https://academic.oup.com/bioinformatics/article/29/1/1/273289)
 
+## Minimum Supported Rust Version
+
+`rust-lapper` supports Rust 1.59 and newer. Rust 1.59 is the first stable
+release that provides the AArch64 intrinsics used by the NEON query backend.
+
 ## Serde Support
 
 `rust-lapper` supports serialization with serde for `Lapper` and `Interval` objects:

--- a/plans/productionization.md
+++ b/plans/productionization.md
@@ -42,6 +42,14 @@ and any increase is intentional and documented.
 
 ## 3. Resolve the `I: 'static` API-bound addition
 
+Status: complete and accepted. Stable Rust has no specialization mechanism that
+can select primitive SIMD kernels while retaining a blanket scalar path for
+every custom `PrimInt`. Safe pointer reinterpretation therefore uses exact
+`TypeId` checks, which require `I: 'static`. This excludes only custom coordinate
+types carrying non-static borrows; it does not require a `Lapper` value to live
+for the program lifetime. Primitive types use SIMD, while `u128`, `i128`, and
+other unmatched owned `PrimInt` types use the tested scalar fallback.
+
 - Measure the public API difference from rust-lapper 1.3.0.
 - Determine whether safe primitive-type SIMD dispatch can avoid `TypeId` and
   the corresponding `I: 'static` bound without restricting custom `PrimInt`

--- a/plans/productionization.md
+++ b/plans/productionization.md
@@ -81,6 +81,12 @@ paired measurements, without adding a workload heuristic or user-visible mode.
 
 ## 5. Run the final CI target matrix
 
+Status: in progress. The matrix now exercises native AArch64 NEON on macOS,
+native x86-64 AVX2 on Linux, and x86-64 scalar dispatch under a QEMU Nehalem
+CPU model. It separately tests default, `with_serde`, `sort_unstable`, and
+all-feature configurations, and compiles scalar-only i686, PowerPC64LE, and
+Wasm targets. The matrix must pass on GitHub before this gate is complete.
+
 - Test AArch64 NEON, x86-64 AVX2, and x86-64 scalar execution.
 - Compile and test the scalar fallback on other supported targets.
 - Cover default features, `with_serde`, and `sort_unstable`.

--- a/plans/productionization.md
+++ b/plans/productionization.md
@@ -62,6 +62,14 @@ actual user impact documented.
 
 ## 4. Measure cached backend and type selection
 
+Status: complete and rejected. A construction-time dispatch experiment stored a
+typed mask function pointer in each `Lapper`, removing per-iterator backend
+selection and per-mixed-block `TypeId` selection. On an Apple M3, paired
+alternating measurements showed query regressions of 4.21% on `1-2`, 2.04% on
+`7-3`, and 1.49% on `8-7`. The cached variant won only 1/15, 0/15, and 0/10
+query pairs respectively. The indirect call costs more than the current
+compiler-folded checks, so the existing dispatch is retained.
+
 - Compare the current per-iterator backend detection and per-mask type
   selection with selection cached at `Lapper` construction.
 - Measure construction, query, and total time on all three retained datasets.

--- a/plans/productionization.md
+++ b/plans/productionization.md
@@ -7,6 +7,12 @@ iteration order, exact overlap semantics, and always-on query algorithm.
 
 ## 1. Validate AVX2 on real Intel/AMD hardware
 
+Status: in progress. On 2026-07-28, GitHub's native x86-64 runner reported an
+AMD EPYC 7763 with AVX2. Runtime dispatch selected AVX2 and every signed and
+unsigned AVX2 mask matched the scalar result. Rosetta separately exercised the
+x86-64 scalar selection. Native three-dataset performance measurements and a
+physical non-AVX2 x86 host remain outstanding.
+
 - Run the complete test suite on native x86-64 with AVX2 available.
 - Verify that the AVX2 backend is selected and executed, rather than only
   inspecting forced-target assembly.
@@ -19,6 +25,11 @@ Pass condition: native AVX2 and non-AVX2 paths are correct, and the native AVX2
 performance record contains no unexplained regression.
 
 ## 2. Decide and document the effective MSRV
+
+Status: complete. The declared MSRV is Rust 1.59.0. The locked all-feature
+library builds on 1.59.0, while 1.58.1 fails because its AArch64 `std::arch`
+intrinsics are still unstable. Rust-lapper 1.3.0 had no declared MSRV and its
+locked all-feature library still builds on Rust 1.56.1.
 
 - Determine the oldest compiler supported by rust-lapper 1.3.0.
 - Identify the oldest compiler accepted by the worked implementation and its

--- a/plans/productionization.md
+++ b/plans/productionization.md
@@ -1,0 +1,63 @@
+# Portable SIMD index production plan
+
+The implementation on `worked/portable-simd-index` is feature-complete as an
+experimental release candidate. Productionization is limited to the five gates
+below; changes should preserve the existing public API, forward borrowed
+iteration order, exact overlap semantics, and always-on query algorithm.
+
+## 1. Validate AVX2 on real Intel/AMD hardware
+
+- Run the complete test suite on native x86-64 with AVX2 available.
+- Verify that the AVX2 backend is selected and executed, rather than only
+  inspecting forced-target assembly.
+- Run the three retained datasets against rust-lapper 1.3.0, the worked Lapper,
+  and the pinned Rust competitors.
+- Test an x86-64 build or host without AVX2 and confirm the scalar fallback.
+- Record CPU, compiler, build flags, raw samples, medians, and overlap counts.
+
+Pass condition: native AVX2 and non-AVX2 paths are correct, and the native AVX2
+performance record contains no unexplained regression.
+
+## 2. Decide and document the effective MSRV
+
+- Determine the oldest compiler supported by rust-lapper 1.3.0.
+- Identify the oldest compiler accepted by the worked implementation and its
+  dependencies.
+- Either retain the existing effective MSRV or choose a deliberate new one.
+- Add the decision to package metadata, CI, and release documentation.
+
+Pass condition: the declared MSRV builds and tests the supported feature set,
+and any increase is intentional and documented.
+
+## 3. Resolve the `I: 'static` API-bound addition
+
+- Measure the public API difference from rust-lapper 1.3.0.
+- Determine whether safe primitive-type SIMD dispatch can avoid `TypeId` and
+  the corresponding `I: 'static` bound without restricting custom `PrimInt`
+  implementations.
+- If it cannot be removed without a larger compatibility or performance cost,
+  document and test the bound as an intentional compatibility decision.
+
+Pass condition: the bound is either eliminated or explicitly accepted with its
+actual user impact documented.
+
+## 4. Measure cached backend and type selection
+
+- Compare the current per-iterator backend detection and per-mask type
+  selection with selection cached at `Lapper` construction.
+- Measure construction, query, and total time on all three retained datasets.
+- Reject function-pointer or cached-dispatch designs that are slower, more
+  fragile, or materially more complex without a demonstrated benefit.
+
+Pass condition: retain the fastest defensible dispatch arrangement based on
+paired measurements, without adding a workload heuristic or user-visible mode.
+
+## 5. Run the final CI target matrix
+
+- Test AArch64 NEON, x86-64 AVX2, and x86-64 scalar execution.
+- Compile and test the scalar fallback on other supported targets.
+- Cover default features, `with_serde`, and `sort_unstable`.
+- Include the declared MSRV and current stable Rust.
+
+Pass condition: every supported target and feature combination is green, with
+native execution for the SIMD backends claimed by the release.

--- a/plans/productionization.md
+++ b/plans/productionization.md
@@ -10,8 +10,9 @@ iteration order, exact overlap semantics, and always-on query algorithm.
 Status: in progress. On 2026-07-28, GitHub's native x86-64 runner reported an
 AMD EPYC 7763 with AVX2. Runtime dispatch selected AVX2 and every signed and
 unsigned AVX2 mask matched the scalar result. Rosetta separately exercised the
-x86-64 scalar selection. Native three-dataset performance measurements and a
-physical non-AVX2 x86 host remain outstanding.
+x86-64 scalar selection, and the final CI matrix ran the complete test suite
+under a QEMU Nehalem CPU model without AVX2. Native three-dataset performance
+measurements and a physical non-AVX2 x86 host remain outstanding.
 
 - Run the complete test suite on native x86-64 with AVX2 available.
 - Verify that the AVX2 backend is selected and executed, rather than only
@@ -81,11 +82,11 @@ paired measurements, without adding a workload heuristic or user-visible mode.
 
 ## 5. Run the final CI target matrix
 
-Status: in progress. The matrix now exercises native AArch64 NEON on macOS,
-native x86-64 AVX2 on Linux, and x86-64 scalar dispatch under a QEMU Nehalem
-CPU model. It separately tests default, `with_serde`, `sort_unstable`, and
-all-feature configurations, and compiles scalar-only i686, PowerPC64LE, and
-Wasm targets. The matrix must pass on GitHub before this gate is complete.
+Status: complete. On 2026-07-28, the final GitHub matrix passed native AArch64
+NEON on macOS, native x86-64 AVX2 on Linux, and the complete x86-64 scalar test
+suite under a QEMU Nehalem CPU model. It passed Rust 1.59 and current stable,
+default, `with_serde`, `sort_unstable`, and all-feature configurations, plus
+scalar-only i686, PowerPC64LE, and Wasm compilation.
 
 - Test AArch64 NEON, x86-64 AVX2, and x86-64 scalar execution.
 - Compile and test the scalar fallback on other supported targets.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,15 +77,17 @@
 //! ```
 use num_traits::{
     identities::{one, zero},
-    PrimInt, Unsigned,
+    PrimInt,
 };
 use std::cmp::Ordering::{self};
 use std::collections::VecDeque;
 
-const INDEX_BLOCK_SIZE: usize = 32;
+mod simd;
+
+use simd::{detect_backend, overlap_mask, MaskBackend, BLOCK_SIZE as INDEX_BLOCK_SIZE};
 
 #[cfg(feature = "with_serde")]
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Represent a range from [start, stop)
 /// Inclusive start, exclusive of stop
@@ -93,7 +95,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Eq, Debug, Clone)]
 pub struct Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     pub start: I,
@@ -103,11 +105,10 @@ where
 
 /// Primary object of the library. The public intervals holds all the intervals and can be used for
 /// iterating / pulling values out of the tree.
-#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Lapper<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     /// List of intervals
@@ -130,9 +131,64 @@ where
     pub overlaps_merged: bool,
 }
 
+#[cfg(feature = "with_serde")]
+impl<I, T> Serialize for Lapper<I, T>
+where
+    I: PrimInt + Ord + Clone + Send + Sync + Serialize,
+    T: Eq + Clone + Send + Sync + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Lapper", 6)?;
+        state.serialize_field("intervals", &self.intervals)?;
+        state.serialize_field("starts", &self.starts)?;
+        state.serialize_field("stops", &self.stops)?;
+        state.serialize_field("max_len", &self.max_len)?;
+        state.serialize_field("cov", &self.cov)?;
+        state.serialize_field("overlaps_merged", &self.overlaps_merged)?;
+        state.end()
+    }
+}
+
+#[cfg(feature = "with_serde")]
+#[derive(Deserialize)]
+#[allow(dead_code)]
+struct SerializedLapper<I, T>
+where
+    I: PrimInt + Ord + Clone + Send + Sync,
+    T: Eq + Clone + Send + Sync,
+{
+    intervals: Vec<Interval<I, T>>,
+    starts: Vec<I>,
+    stops: Vec<I>,
+    max_len: I,
+    cov: Option<I>,
+    overlaps_merged: bool,
+}
+
+#[cfg(feature = "with_serde")]
+impl<'de, I, T> Deserialize<'de> for Lapper<I, T>
+where
+    I: PrimInt + Ord + Clone + Send + Sync + Deserialize<'de> + 'static,
+    T: Eq + Clone + Send + Sync + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let serialized = SerializedLapper::<I, T>::deserialize(deserializer)?;
+        let mut lapper = Self::new(serialized.intervals);
+        lapper.cov = serialized.cov;
+        lapper.overlaps_merged = serialized.overlaps_merged;
+        Ok(lapper)
+    }
+}
+
 impl<I, T> Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     /// Compute the intsect between two intervals
@@ -152,7 +208,7 @@ where
 
 impl<I, T> Ord for Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]
@@ -167,7 +223,7 @@ where
 
 impl<I, T> PartialOrd for Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]
@@ -178,7 +234,7 @@ where
 
 impl<I, T> PartialEq for Interval<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
     T: Eq + Clone + Send + Sync,
 {
     #[inline]
@@ -189,7 +245,7 @@ where
 
 impl<I, T> Lapper<I, T>
 where
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync + 'static,
     T: Eq + Clone + Send + Sync,
 {
     /// Create a new instance of Lapper by passing in a vector of Intervals. This vector will
@@ -208,81 +264,87 @@ where
         #[cfg(not(feature = "sort_unstable"))]
         intervals.sort();
 
-        let (starts, mut stops): (Vec<_>, Vec<_>) =
-            intervals.iter().map(|x| (x.start, x.stop)).unzip();
-        let stops_by_start = stops.clone();
+        let mut lapper = Lapper {
+            intervals,
+            starts: Vec::new(),
+            stops: Vec::new(),
+            stops_by_start: Vec::new(),
+            block_index: Vec::new(),
+            block_max_ends: Vec::new(),
+            block_min_ends: Vec::new(),
+            block_prefix_max_ends: Vec::new(),
+            max_len: zero::<I>(),
+            cov: None,
+            overlaps_merged: false,
+        };
+        lapper.rebuild_derived();
+        lapper
+    }
 
-        #[cfg(feature = "sort_unstable")]
-        {
-            stops.sort_unstable();
-        }
+    fn rebuild_derived(&mut self) {
+        self.starts.clear();
+        self.stops.clear();
+        self.stops_by_start.clear();
+        self.starts.reserve(self.intervals.len());
+        self.stops.reserve(self.intervals.len());
+        self.stops_by_start.reserve(self.intervals.len());
 
-        #[cfg(not(feature = "sort_unstable"))]
-        {
-            stops.sort();
-        }
-
-        let mut max_len = zero::<I>();
-        for interval in &intervals {
-            let i_len = interval
+        self.max_len = zero::<I>();
+        for interval in &self.intervals {
+            self.starts.push(interval.start);
+            self.stops.push(interval.stop);
+            self.stops_by_start.push(interval.stop);
+            let length = interval
                 .stop
                 .checked_sub(&interval.start)
                 .unwrap_or_else(zero::<I>);
-            if i_len > max_len {
-                max_len = i_len;
+            if length > self.max_len {
+                self.max_len = length;
             }
         }
 
-        let mut block_max_ends = Vec::new();
-        let mut block_min_ends = Vec::new();
-        for block in intervals.chunks(INDEX_BLOCK_SIZE) {
+        #[cfg(feature = "sort_unstable")]
+        self.stops.sort_unstable();
+
+        #[cfg(not(feature = "sort_unstable"))]
+        self.stops.sort();
+
+        self.block_max_ends.clear();
+        self.block_min_ends.clear();
+        let block_count = self.intervals.len().div_ceil(INDEX_BLOCK_SIZE);
+        self.block_max_ends.reserve(block_count);
+        self.block_min_ends.reserve(block_count);
+        for block in self.intervals.chunks(INDEX_BLOCK_SIZE) {
             let mut max_end = block[0].stop;
             let mut min_end = max_end;
             for interval in &block[1..] {
-                if interval.stop > max_end {
-                    max_end = interval.stop;
-                }
-                if interval.stop < min_end {
-                    min_end = interval.stop;
-                }
+                max_end = std::cmp::max(max_end, interval.stop);
+                min_end = std::cmp::min(min_end, interval.stop);
             }
-            block_max_ends.push(max_end);
-            block_min_ends.push(min_end);
+            self.block_max_ends.push(max_end);
+            self.block_min_ends.push(min_end);
         }
 
-        let block_count = block_max_ends.len();
-        let mut block_index = vec![block_count; block_count];
+        self.block_index.clear();
+        self.block_index.resize(block_count, block_count);
         let mut stack = Vec::<usize>::new();
-        for i in (0..block_count).rev() {
+        for block in (0..block_count).rev() {
             while stack
                 .last()
-                .is_some_and(|j| block_max_ends[*j] <= block_max_ends[i])
+                .is_some_and(|next| self.block_max_ends[*next] <= self.block_max_ends[block])
             {
                 stack.pop();
             }
-            block_index[i] = stack.last().copied().unwrap_or(block_count);
-            stack.push(i);
+            self.block_index[block] = stack.last().copied().unwrap_or(block_count);
+            stack.push(block);
         }
 
-        let mut block_prefix_max_ends = block_max_ends.clone();
-        for i in 1..block_prefix_max_ends.len() {
-            if block_prefix_max_ends[i] < block_prefix_max_ends[i - 1] {
-                block_prefix_max_ends[i] = block_prefix_max_ends[i - 1];
-            }
-        }
-
-        Lapper {
-            intervals,
-            starts,
-            stops,
-            stops_by_start,
-            block_index,
-            block_max_ends,
-            block_min_ends,
-            block_prefix_max_ends,
-            max_len,
-            cov: None,
-            overlaps_merged: false,
+        self.block_prefix_max_ends.clone_from(&self.block_max_ends);
+        for block in 1..block_count {
+            self.block_prefix_max_ends[block] = std::cmp::max(
+                self.block_prefix_max_ends[block - 1],
+                self.block_prefix_max_ends[block],
+            );
         }
     }
 
@@ -309,16 +371,9 @@ where
     ///
     /// ```
     pub fn insert(&mut self, elem: Interval<I, T>) {
-        let starts_insert_index = Self::bsearch_seq(elem.start, &self.starts);
-        let stops_insert_index = Self::bsearch_seq(elem.stop, &self.stops);
         let intervals_insert_index = Self::bsearch_seq_ref(&elem, &self.intervals);
-        let i_len = elem.stop.checked_sub(&elem.start).unwrap_or_else(zero::<I>);
-        if i_len > self.max_len {
-            self.max_len = i_len;
-        }
-        self.starts.insert(starts_insert_index, elem.start);
-        self.stops.insert(stops_insert_index, elem.stop);
         self.intervals.insert(intervals_insert_index, elem);
+        self.rebuild_derived();
         self.cov = None;
         self.overlaps_merged = false;
     }
@@ -440,30 +495,7 @@ where
                 })
                 .collect();
         }
-        // Fix the starts and stops used by counts
-        let (mut starts, mut stops): (Vec<_>, Vec<_>) =
-            self.intervals.iter().map(|x| (x.start, x.stop)).unzip();
-
-        #[cfg(feature = "sort_unstable")]
-        {
-            starts.sort_unstable();
-            stops.sort_unstable();
-        }
-
-        #[cfg(not(feature = "sort_unstable"))]
-        {
-            starts.sort();
-            stops.sort();
-        }
-
-        self.starts = starts;
-        self.stops = stops;
-        self.max_len = self
-            .intervals
-            .iter()
-            .map(|x| x.stop.checked_sub(&x.start).unwrap_or_else(zero::<I>))
-            .max()
-            .unwrap_or_else(zero::<I>);
+        self.rebuild_derived();
     }
 
     /// Determine the first index that we should start checking for overlaps for via a binary
@@ -642,6 +674,7 @@ where
             inner: self,
             merged: merged_lapper,
             curr_merged_pos: zero::<I>(),
+            initialized: false,
             curr_pos: 0,
             cursor: 0,
             end: merged_len,
@@ -661,8 +694,9 @@ where
     #[inline]
     pub fn count(&self, start: I, stop: I) -> usize {
         let len = self.intervals.len();
-        // Plus one to account for half-openness of lapper intervals compared to BITS paper
-        let first = Self::bsearch_seq(start + one::<I>(), &self.stops);
+        let first = self
+            .stops
+            .partition_point(|interval_stop| *interval_stop <= start);
         let last = Self::bsearch_seq(stop, &self.starts);
         let num_cant_after = len - last;
         len - first - num_cant_after
@@ -684,8 +718,12 @@ where
             * INDEX_BLOCK_SIZE;
         IterFind {
             inner: self,
-            off,
             next_block_start: off,
+            mask_block_start: 0,
+            mask: 0,
+            dense_next: 0,
+            dense_end: 0,
+            backend: detect_backend(),
             start,
             stop,
         }
@@ -708,152 +746,59 @@ where
     /// ```
     #[inline]
     pub fn seek<'a>(&'a self, start: I, stop: I, cursor: &mut usize) -> IterFind<'a, I, T> {
+        let earliest_start = start
+            .checked_sub(&self.max_len)
+            .unwrap_or_else(I::min_value);
         if *cursor == 0 || (*cursor < self.intervals.len() && self.intervals[*cursor].start > start)
         {
-            *cursor = Self::lower_bound(
-                start.checked_sub(&self.max_len).unwrap_or_else(zero::<I>),
-                &self.intervals,
-            );
+            *cursor = Self::lower_bound(earliest_start, &self.intervals);
         }
 
         while *cursor + 1 < self.intervals.len()
-            && self.intervals[*cursor + 1].start
-                < start.checked_sub(&self.max_len).unwrap_or_else(zero::<I>)
+            && self.intervals[*cursor + 1].start < earliest_start
         {
             *cursor += 1;
         }
 
         IterFind {
             inner: self,
-            off: *cursor,
-            next_block_start: (*cursor).div_ceil(INDEX_BLOCK_SIZE) * INDEX_BLOCK_SIZE,
-            start,
-            stop,
-        }
-    }
-}
-
-impl<T> Lapper<u32, T>
-where
-    T: Eq + Clone + Send + Sync,
-{
-    /// Experimental forward iterator that computes and retains one overlap
-    /// mask for each candidate block.
-    #[inline]
-    pub fn find_block_mask(&self, start: u32, stop: u32) -> IterFindBlockMask<'_, T> {
-        let next_block_start = self
-            .block_prefix_max_ends
-            .partition_point(|max_end| *max_end <= start)
-            * INDEX_BLOCK_SIZE;
-        IterFindBlockMask {
-            inner: self,
-            next_block_start,
+            next_block_start: (*cursor / INDEX_BLOCK_SIZE) * INDEX_BLOCK_SIZE,
             mask_block_start: 0,
             mask: 0,
             dense_next: 0,
             dense_end: 0,
+            backend: detect_backend(),
             start,
             stop,
         }
     }
 }
 
-/// Experimental `u32` iterator that consumes a saved candidate-block mask.
+/// Find Iterator
 #[derive(Debug)]
-pub struct IterFindBlockMask<'a, T>
+pub struct IterFind<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
+    I: PrimInt + Ord + Clone + Send + Sync,
 {
-    inner: &'a Lapper<u32, T>,
+    inner: &'a Lapper<I, T>,
     next_block_start: usize,
     mask_block_start: usize,
     mask: u32,
     dense_next: usize,
     dense_end: usize,
-    start: u32,
-    stop: u32,
+    backend: MaskBackend,
+    start: I,
+    stop: I,
 }
 
-#[cfg(target_arch = "aarch64")]
-#[inline(always)]
-fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32) -> u32 {
-    use std::arch::aarch64::{
-        vaddvq_u16, vaddvq_u32, vandq_u16, vandq_u32, vcgtq_u32, vcombine_u16, vdupq_n_u32,
-        vld1q_u16, vld1q_u32, vld1q_u32_x2, vmovn_u32,
-    };
-
-    debug_assert_eq!(starts.len(), stops.len());
-    debug_assert!(starts.len() <= INDEX_BLOCK_SIZE);
-
-    let mut mask = 0_u32;
-    let simd_len = starts.len() / 4 * 4;
-
-    unsafe {
-        let query_start = vdupq_n_u32(query_start);
-        let query_stop = vdupq_n_u32(query_stop);
-        let weights4 = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
-        let weights8 = vld1q_u16([1_u16, 2, 4, 8, 16, 32, 64, 128].as_ptr());
-        let mut lane = 0;
-        while lane + 8 <= simd_len {
-            let lane_starts = vld1q_u32_x2(starts.as_ptr().add(lane));
-            let lane_stops = vld1q_u32_x2(stops.as_ptr().add(lane));
-            let overlapping0 = vandq_u32(
-                vcgtq_u32(lane_stops.0, query_start),
-                vcgtq_u32(query_stop, lane_starts.0),
-            );
-            let overlapping1 = vandq_u32(
-                vcgtq_u32(lane_stops.1, query_start),
-                vcgtq_u32(query_stop, lane_starts.1),
-            );
-            let overlapping = vcombine_u16(vmovn_u32(overlapping0), vmovn_u32(overlapping1));
-            let bits = vaddvq_u16(vandq_u16(overlapping, weights8));
-            mask |= u32::from(bits) << lane;
-            lane += 8;
-        }
-        while lane < simd_len {
-            let lane_starts = vld1q_u32(starts.as_ptr().add(lane));
-            let lane_stops = vld1q_u32(stops.as_ptr().add(lane));
-            let overlapping = vandq_u32(
-                vcgtq_u32(lane_stops, query_start),
-                vcgtq_u32(query_stop, lane_starts),
-            );
-            let bits = vaddvq_u32(vandq_u32(overlapping, weights4));
-            mask |= bits << lane;
-            lane += 4;
-        }
-    }
-
-    for lane in simd_len..starts.len() {
-        if stops[lane] > query_start && starts[lane] < query_stop {
-            mask |= 1 << lane;
-        }
-    }
-    mask
-}
-
-#[cfg(not(target_arch = "aarch64"))]
-#[inline(always)]
-fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32) -> u32 {
-    debug_assert_eq!(starts.len(), stops.len());
-    debug_assert!(starts.len() <= INDEX_BLOCK_SIZE);
-
-    let mut mask = 0_u32;
-    for lane in 0..starts.len() {
-        if stops[lane] > query_start && starts[lane] < query_stop {
-            mask |= 1 << lane;
-        }
-    }
-    mask
-}
-
-impl<'a, T> Iterator for IterFindBlockMask<'a, T>
+impl<'a, I, T> IterFind<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
+    I: PrimInt + Ord + Clone + Send + Sync + 'static,
 {
-    type Item = &'a Interval<u32, T>;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
+    #[inline(always)]
+    fn next_blockwise(&mut self) -> Option<&'a Interval<I, T>> {
         loop {
             if self.dense_next < self.dense_end {
                 let index = self.dense_next;
@@ -868,21 +813,28 @@ where
             }
 
             let block_start = self.next_block_start;
-            if block_start >= self.inner.intervals.len() {
+            if block_start >= self.inner.starts.len() {
                 return None;
             }
+
+            // Private arrays are rebuilt together by constructors, mutations,
+            // and deserialization. Public interval edits cannot extend this bound.
             if unsafe { *self.inner.starts.get_unchecked(block_start) } >= self.stop {
                 return None;
             }
 
             let block = block_start / INDEX_BLOCK_SIZE;
             if unsafe { *self.inner.block_max_ends.get_unchecked(block) } <= self.start {
-                self.next_block_start =
-                    unsafe { *self.inner.block_index.get_unchecked(block) } * INDEX_BLOCK_SIZE;
+                let next_block = unsafe { *self.inner.block_index.get_unchecked(block) };
+                debug_assert!(
+                    next_block <= self.inner.block_index.len(),
+                    "Lapper block index is corrupt"
+                );
+                self.next_block_start = next_block * INDEX_BLOCK_SIZE;
                 continue;
             }
 
-            let block_end = (block_start + INDEX_BLOCK_SIZE).min(self.inner.intervals.len());
+            let block_end = (block_start + INDEX_BLOCK_SIZE).min(self.inner.starts.len());
             if unsafe { *self.inner.block_min_ends.get_unchecked(block) } > self.start {
                 let starts = unsafe { self.inner.starts.get_unchecked(block_start..block_end) };
                 let active_len = if unsafe { *starts.get_unchecked(starts.len() - 1) } < self.stop {
@@ -895,7 +847,7 @@ where
                 self.next_block_start = if active_len == starts.len() {
                     block_end
                 } else {
-                    self.inner.intervals.len()
+                    self.inner.starts.len()
                 };
                 continue;
             }
@@ -903,6 +855,7 @@ where
             self.mask_block_start = block_start;
             self.next_block_start = block_end;
             self.mask = overlap_mask(
+                self.backend,
                 unsafe { self.inner.starts.get_unchecked(block_start..block_end) },
                 unsafe {
                     self.inner
@@ -916,56 +869,10 @@ where
     }
 }
 
-/// Find Iterator
-#[derive(Debug)]
-pub struct IterFind<'a, I, T>
-where
-    T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
-{
-    inner: &'a Lapper<I, T>,
-    off: usize,
-    next_block_start: usize,
-    start: I,
-    stop: I,
-}
-
-impl<'a, I, T> IterFind<'a, I, T>
-where
-    T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
-{
-    #[inline(always)]
-    fn next_blockwise(&mut self) -> Option<&'a Interval<I, T>> {
-        while self.off < self.inner.intervals.len() {
-            let curr = self.off;
-            if curr == self.next_block_start {
-                let block = curr / INDEX_BLOCK_SIZE;
-                if self.inner.block_max_ends[block] <= self.start {
-                    self.off = self.inner.block_index[block] * INDEX_BLOCK_SIZE;
-                    self.next_block_start = self.off;
-                    continue;
-                }
-                self.next_block_start += INDEX_BLOCK_SIZE;
-            }
-
-            let interval = &self.inner.intervals[curr];
-            self.off += 1;
-            if interval.start >= self.stop {
-                break;
-            }
-            if interval.stop > self.start {
-                return Some(interval);
-            }
-        }
-        None
-    }
-}
-
 impl<'a, I, T> Iterator for IterFind<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync + 'static,
 {
     type Item = &'a Interval<I, T>;
 
@@ -980,28 +887,30 @@ where
 pub struct IterDepth<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
 {
     inner: &'a Lapper<I, T>,
     merged: Lapper<I, bool>, // A lapper that is the merged_lapper of inner
     curr_merged_pos: I,      // Current start position in current interval
-    curr_pos: usize,         // In merged list of non-overlapping intervals
-    cursor: usize,           // cursor for seek over inner lapper
-    end: usize,              // len of merged
+    initialized: bool,
+    curr_pos: usize, // In merged list of non-overlapping intervals
+    cursor: usize,   // cursor for seek over inner lapper
+    end: usize,      // len of merged
 }
 
 impl<'a, I, T> Iterator for IterDepth<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync + 'static,
 {
     type Item = Interval<I, I>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let mut interval: &Interval<I, bool> = &self.merged.intervals[self.curr_pos];
-        if self.curr_merged_pos == zero::<I>() {
+        if !self.initialized {
             self.curr_merged_pos = interval.start;
+            self.initialized = true;
         }
         if interval.stop == self.curr_merged_pos {
             if self.curr_pos + 1 != self.end {
@@ -1044,7 +953,7 @@ where
 pub struct IterLapper<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
 {
     inner: &'a Lapper<I, T>,
     pos: usize,
@@ -1053,7 +962,7 @@ where
 impl<'a, I, T> Iterator for IterLapper<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
 {
     type Item = &'a Interval<I, T>;
 
@@ -1070,7 +979,7 @@ where
 impl<I, T> IntoIterator for Lapper<I, T>
 where
     T: Eq + Clone + Send + Sync,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
 {
     type Item = Interval<I, T>;
     type IntoIter = ::std::vec::IntoIter<Self::Item>;
@@ -1083,7 +992,7 @@ where
 impl<'a, I, T> IntoIterator for &'a Lapper<I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
 {
     type Item = &'a Interval<I, T>;
     type IntoIter = std::slice::Iter<'a, Interval<I, T>>;
@@ -1096,7 +1005,7 @@ where
 impl<'a, I, T> IntoIterator for &'a mut Lapper<I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
-    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+    I: PrimInt + Ord + Clone + Send + Sync,
 {
     type Item = &'a mut Interval<I, T>;
     type IntoIter = std::slice::IterMut<'a, Interval<I, T>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,7 +777,9 @@ where
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32) -> u32 {
-    use std::arch::aarch64::{vaddvq_u32, vandq_u32, vcgtq_u32, vdupq_n_u32, vld1q_u32};
+    use std::arch::aarch64::{
+        vaddvq_u32, vandq_u32, vcgtq_u32, vdupq_n_u32, vld1q_u32, vld1q_u32_x2,
+    };
 
     debug_assert_eq!(starts.len(), stops.len());
     debug_assert!(starts.len() <= INDEX_BLOCK_SIZE);
@@ -790,6 +792,22 @@ fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32
         let query_stop = vdupq_n_u32(query_stop);
         let bit_weights = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
         let mut lane = 0;
+        while lane + 8 <= simd_len {
+            let lane_starts = vld1q_u32_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u32_x2(stops.as_ptr().add(lane));
+            let overlapping0 = vandq_u32(
+                vcgtq_u32(lane_stops.0, query_start),
+                vcgtq_u32(query_stop, lane_starts.0),
+            );
+            let overlapping1 = vandq_u32(
+                vcgtq_u32(lane_stops.1, query_start),
+                vcgtq_u32(query_stop, lane_starts.1),
+            );
+            let bits0 = vaddvq_u32(vandq_u32(overlapping0, bit_weights));
+            let bits1 = vaddvq_u32(vandq_u32(overlapping1, bit_weights));
+            mask |= (bits0 | (bits1 << 4)) << lane;
+            lane += 8;
+        }
         while lane < simd_len {
             let lane_starts = vld1q_u32(starts.as_ptr().add(lane));
             let lane_stops = vld1q_u32(stops.as_ptr().add(lane));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,7 +778,8 @@ where
 #[inline(always)]
 fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32) -> u32 {
     use std::arch::aarch64::{
-        vaddvq_u32, vandq_u32, vcgtq_u32, vdupq_n_u32, vld1q_u32, vld1q_u32_x2,
+        vaddvq_u16, vaddvq_u32, vandq_u16, vandq_u32, vcgtq_u32, vcombine_u16, vdupq_n_u32,
+        vld1q_u16, vld1q_u32, vld1q_u32_x2, vmovn_u32,
     };
 
     debug_assert_eq!(starts.len(), stops.len());
@@ -790,7 +791,8 @@ fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32
     unsafe {
         let query_start = vdupq_n_u32(query_start);
         let query_stop = vdupq_n_u32(query_stop);
-        let bit_weights = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
+        let weights4 = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
+        let weights8 = vld1q_u16([1_u16, 2, 4, 8, 16, 32, 64, 128].as_ptr());
         let mut lane = 0;
         while lane + 8 <= simd_len {
             let lane_starts = vld1q_u32_x2(starts.as_ptr().add(lane));
@@ -803,9 +805,9 @@ fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32
                 vcgtq_u32(lane_stops.1, query_start),
                 vcgtq_u32(query_stop, lane_starts.1),
             );
-            let bits0 = vaddvq_u32(vandq_u32(overlapping0, bit_weights));
-            let bits1 = vaddvq_u32(vandq_u32(overlapping1, bit_weights));
-            mask |= (bits0 | (bits1 << 4)) << lane;
+            let overlapping = vcombine_u16(vmovn_u32(overlapping0), vmovn_u32(overlapping1));
+            let bits = vaddvq_u16(vandq_u16(overlapping, weights8));
+            mask |= u32::from(bits) << lane;
             lane += 8;
         }
         while lane < simd_len {
@@ -815,7 +817,7 @@ fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32
                 vcgtq_u32(lane_stops, query_start),
                 vcgtq_u32(query_stop, lane_starts),
             );
-            let bits = vaddvq_u32(vandq_u32(overlapping, bit_weights));
+            let bits = vaddvq_u32(vandq_u32(overlapping, weights4));
             mask |= bits << lane;
             lane += 4;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,9 @@ where
 
         self.block_max_ends.clear();
         self.block_min_ends.clear();
-        let block_count = self.intervals.len().div_ceil(INDEX_BLOCK_SIZE);
+        let interval_count = self.intervals.len();
+        let block_count =
+            interval_count / INDEX_BLOCK_SIZE + usize::from(interval_count % INDEX_BLOCK_SIZE != 0);
         self.block_max_ends.reserve(block_count);
         self.block_min_ends.reserve(block_count);
         for block in self.intervals.chunks(INDEX_BLOCK_SIZE) {
@@ -329,10 +331,9 @@ where
         self.block_index.resize(block_count, block_count);
         let mut stack = Vec::<usize>::new();
         for block in (0..block_count).rev() {
-            while stack
-                .last()
-                .is_some_and(|next| self.block_max_ends[*next] <= self.block_max_ends[block])
-            {
+            while stack.last().map_or(false, |&next| {
+                self.block_max_ends[next] <= self.block_max_ends[block]
+            }) {
                 stack.pop();
             }
             self.block_index[block] = stack.last().copied().unwrap_or(block_count);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,26 +282,26 @@ where
     }
 
     fn rebuild_derived(&mut self) {
-        self.starts.clear();
-        self.stops.clear();
-        self.stops_by_start.clear();
-        self.starts.reserve(self.intervals.len());
-        self.stops.reserve(self.intervals.len());
-        self.stops_by_start.reserve(self.intervals.len());
+        let (starts, stops_by_start): (Vec<_>, Vec<_>) = self
+            .intervals
+            .iter()
+            .map(|interval| (interval.start, interval.stop))
+            .unzip();
+        self.starts = starts;
+        self.stops = stops_by_start.clone();
+        self.stops_by_start = stops_by_start;
 
-        self.max_len = zero::<I>();
-        for interval in &self.intervals {
-            self.starts.push(interval.start);
-            self.stops.push(interval.stop);
-            self.stops_by_start.push(interval.stop);
-            let length = interval
-                .stop
-                .checked_sub(&interval.start)
-                .unwrap_or_else(zero::<I>);
-            if length > self.max_len {
-                self.max_len = length;
-            }
-        }
+        self.max_len = self
+            .intervals
+            .iter()
+            .map(|interval| {
+                interval
+                    .stop
+                    .checked_sub(&interval.start)
+                    .unwrap_or_else(zero::<I>)
+            })
+            .max()
+            .unwrap_or_else(zero::<I>);
 
         #[cfg(feature = "sort_unstable")]
         self.stops.sort_unstable();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,9 +777,7 @@ where
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32) -> u32 {
-    use std::arch::aarch64::{
-        vandq_u32, vcgtq_u32, vdupq_n_u32, vgetq_lane_u32, vld1q_u32, vshrq_n_u32,
-    };
+    use std::arch::aarch64::{vaddvq_u32, vandq_u32, vcgtq_u32, vdupq_n_u32, vld1q_u32};
 
     debug_assert_eq!(starts.len(), stops.len());
     debug_assert!(starts.len() <= INDEX_BLOCK_SIZE);
@@ -790,6 +788,7 @@ fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32
     unsafe {
         let query_start = vdupq_n_u32(query_start);
         let query_stop = vdupq_n_u32(query_stop);
+        let bit_weights = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
         let mut lane = 0;
         while lane < simd_len {
             let lane_starts = vld1q_u32(starts.as_ptr().add(lane));
@@ -798,11 +797,8 @@ fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32
                 vcgtq_u32(lane_stops, query_start),
                 vcgtq_u32(query_stop, lane_starts),
             );
-            let bits = vshrq_n_u32::<31>(overlapping);
-            mask |= vgetq_lane_u32::<0>(bits) << lane;
-            mask |= vgetq_lane_u32::<1>(bits) << (lane + 1);
-            mask |= vgetq_lane_u32::<2>(bits) << (lane + 2);
-            mask |= vgetq_lane_u32::<3>(bits) << (lane + 3);
+            let bits = vaddvq_u32(vandq_u32(overlapping, bit_weights));
+            mask |= bits << lane;
             lane += 4;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,8 @@ use num_traits::{
 use std::cmp::Ordering::{self};
 use std::collections::VecDeque;
 
+const INDEX_BLOCK_SIZE: usize = 32;
+
 #[cfg(feature = "with_serde")]
 use serde::{Deserialize, Serialize};
 
@@ -114,6 +116,9 @@ where
     starts: Vec<I>,
     /// Sorted list of end positions,
     stops: Vec<I>,
+    block_index: Vec<usize>,
+    block_max_ends: Vec<I>,
+    block_prefix_max_ends: Vec<I>,
     /// The length of the longest interval
     max_len: I,
     /// The calculated number of positions covered by the intervals
@@ -216,7 +221,7 @@ where
         }
 
         let mut max_len = zero::<I>();
-        for interval in intervals.iter() {
+        for interval in &intervals {
             let i_len = interval
                 .stop
                 .checked_sub(&interval.start)
@@ -225,10 +230,46 @@ where
                 max_len = i_len;
             }
         }
+
+        let mut block_max_ends = Vec::new();
+        for block in intervals.chunks(INDEX_BLOCK_SIZE) {
+            let mut max_end = block[0].stop;
+            for interval in &block[1..] {
+                if interval.stop > max_end {
+                    max_end = interval.stop;
+                }
+            }
+            block_max_ends.push(max_end);
+        }
+
+        let block_count = block_max_ends.len();
+        let mut block_index = vec![block_count; block_count];
+        let mut stack = Vec::<usize>::new();
+        for i in (0..block_count).rev() {
+            while stack
+                .last()
+                .is_some_and(|j| block_max_ends[*j] <= block_max_ends[i])
+            {
+                stack.pop();
+            }
+            block_index[i] = stack.last().copied().unwrap_or(block_count);
+            stack.push(i);
+        }
+
+        let mut block_prefix_max_ends = block_max_ends.clone();
+        for i in 1..block_prefix_max_ends.len() {
+            if block_prefix_max_ends[i] < block_prefix_max_ends[i - 1] {
+                block_prefix_max_ends[i] = block_prefix_max_ends[i - 1];
+            }
+        }
+
         Lapper {
             intervals,
             starts,
             stops,
+            block_index,
+            block_max_ends,
+            block_prefix_max_ends,
             max_len,
             cov: None,
             overlaps_merged: false,
@@ -629,10 +670,10 @@ where
     pub fn find(&self, start: I, stop: I) -> IterFind<'_, I, T> {
         IterFind {
             inner: self,
-            off: Self::lower_bound(
-                start.checked_sub(&self.max_len).unwrap_or_else(zero::<I>),
-                &self.intervals,
-            ),
+            off: self
+                .block_prefix_max_ends
+                .partition_point(|max_end| *max_end <= start)
+                * INDEX_BLOCK_SIZE,
             start,
             stop,
         }
@@ -692,6 +733,36 @@ where
     stop: I,
 }
 
+impl<'a, I, T> IterFind<'a, I, T>
+where
+    T: Eq + Clone + Send + Sync + 'a,
+    I: PrimInt + Unsigned + Ord + Clone + Send + Sync,
+{
+    #[inline(always)]
+    fn next_blockwise(&mut self) -> Option<&'a Interval<I, T>> {
+        while self.off < self.inner.intervals.len() {
+            let curr = self.off;
+            if curr.is_multiple_of(INDEX_BLOCK_SIZE) {
+                let block = curr / INDEX_BLOCK_SIZE;
+                if self.inner.block_max_ends[block] <= self.start {
+                    self.off = self.inner.block_index[block] * INDEX_BLOCK_SIZE;
+                    continue;
+                }
+            }
+
+            let interval = &self.inner.intervals[curr];
+            self.off += 1;
+            if interval.start >= self.stop {
+                break;
+            }
+            if interval.stop > self.start {
+                return Some(interval);
+            }
+        }
+        None
+    }
+}
+
 impl<'a, I, T> Iterator for IterFind<'a, I, T>
 where
     T: Eq + Clone + Send + Sync + 'a,
@@ -700,20 +771,8 @@ where
     type Item = &'a Interval<I, T>;
 
     #[inline]
-    // interval.start < stop && interval.stop > start
     fn next(&mut self) -> Option<Self::Item> {
-        while self.off < self.inner.intervals.len() {
-            //let mut generator = self.inner.intervals[self.off..].iter();
-            //while let Some(interval) = generator.next() {
-            let interval = &self.inner.intervals[self.off];
-            self.off += 1;
-            if interval.overlap(self.start, self.stop) {
-                return Some(interval);
-            } else if interval.start >= self.stop {
-                break;
-            }
-        }
-        None
+        self.next_blockwise()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,8 +116,11 @@ where
     starts: Vec<I>,
     /// Sorted list of end positions,
     stops: Vec<I>,
+    /// End positions in the same order as `intervals`, for block-mask queries.
+    stops_by_start: Vec<I>,
     block_index: Vec<usize>,
     block_max_ends: Vec<I>,
+    block_min_ends: Vec<I>,
     block_prefix_max_ends: Vec<I>,
     /// The length of the longest interval
     max_len: I,
@@ -205,18 +208,17 @@ where
         #[cfg(not(feature = "sort_unstable"))]
         intervals.sort();
 
-        let (mut starts, mut stops): (Vec<_>, Vec<_>) =
+        let (starts, mut stops): (Vec<_>, Vec<_>) =
             intervals.iter().map(|x| (x.start, x.stop)).unzip();
+        let stops_by_start = stops.clone();
 
         #[cfg(feature = "sort_unstable")]
         {
-            starts.sort_unstable();
             stops.sort_unstable();
         }
 
         #[cfg(not(feature = "sort_unstable"))]
         {
-            starts.sort();
             stops.sort();
         }
 
@@ -232,14 +234,20 @@ where
         }
 
         let mut block_max_ends = Vec::new();
+        let mut block_min_ends = Vec::new();
         for block in intervals.chunks(INDEX_BLOCK_SIZE) {
             let mut max_end = block[0].stop;
+            let mut min_end = max_end;
             for interval in &block[1..] {
                 if interval.stop > max_end {
                     max_end = interval.stop;
                 }
+                if interval.stop < min_end {
+                    min_end = interval.stop;
+                }
             }
             block_max_ends.push(max_end);
+            block_min_ends.push(min_end);
         }
 
         let block_count = block_max_ends.len();
@@ -267,8 +275,10 @@ where
             intervals,
             starts,
             stops,
+            stops_by_start,
             block_index,
             block_max_ends,
+            block_min_ends,
             block_prefix_max_ends,
             max_len,
             cov: None,
@@ -668,12 +678,14 @@ where
     /// ```
     #[inline]
     pub fn find(&self, start: I, stop: I) -> IterFind<'_, I, T> {
+        let off = self
+            .block_prefix_max_ends
+            .partition_point(|max_end| *max_end <= start)
+            * INDEX_BLOCK_SIZE;
         IterFind {
             inner: self,
-            off: self
-                .block_prefix_max_ends
-                .partition_point(|max_end| *max_end <= start)
-                * INDEX_BLOCK_SIZE,
+            off,
+            next_block_start: off,
             start,
             stop,
         }
@@ -714,8 +726,173 @@ where
         IterFind {
             inner: self,
             off: *cursor,
+            next_block_start: (*cursor).div_ceil(INDEX_BLOCK_SIZE) * INDEX_BLOCK_SIZE,
             start,
             stop,
+        }
+    }
+}
+
+impl<T> Lapper<u32, T>
+where
+    T: Eq + Clone + Send + Sync,
+{
+    /// Experimental forward iterator that computes and retains one overlap
+    /// mask for each candidate block.
+    #[inline]
+    pub fn find_block_mask(&self, start: u32, stop: u32) -> IterFindBlockMask<'_, T> {
+        let next_block_start = self
+            .block_prefix_max_ends
+            .partition_point(|max_end| *max_end <= start)
+            * INDEX_BLOCK_SIZE;
+        IterFindBlockMask {
+            inner: self,
+            next_block_start,
+            mask_block_start: 0,
+            mask: 0,
+            dense_next: 0,
+            dense_end: 0,
+            start,
+            stop,
+        }
+    }
+}
+
+/// Experimental `u32` iterator that consumes a saved candidate-block mask.
+#[derive(Debug)]
+pub struct IterFindBlockMask<'a, T>
+where
+    T: Eq + Clone + Send + Sync + 'a,
+{
+    inner: &'a Lapper<u32, T>,
+    next_block_start: usize,
+    mask_block_start: usize,
+    mask: u32,
+    dense_next: usize,
+    dense_end: usize,
+    start: u32,
+    stop: u32,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32) -> u32 {
+    use std::arch::aarch64::{
+        vandq_u32, vcgtq_u32, vdupq_n_u32, vgetq_lane_u32, vld1q_u32, vshrq_n_u32,
+    };
+
+    debug_assert_eq!(starts.len(), stops.len());
+    debug_assert!(starts.len() <= INDEX_BLOCK_SIZE);
+
+    let mut mask = 0_u32;
+    let simd_len = starts.len() / 4 * 4;
+
+    unsafe {
+        let query_start = vdupq_n_u32(query_start);
+        let query_stop = vdupq_n_u32(query_stop);
+        let mut lane = 0;
+        while lane < simd_len {
+            let lane_starts = vld1q_u32(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u32(stops.as_ptr().add(lane));
+            let overlapping = vandq_u32(
+                vcgtq_u32(lane_stops, query_start),
+                vcgtq_u32(query_stop, lane_starts),
+            );
+            let bits = vshrq_n_u32::<31>(overlapping);
+            mask |= vgetq_lane_u32::<0>(bits) << lane;
+            mask |= vgetq_lane_u32::<1>(bits) << (lane + 1);
+            mask |= vgetq_lane_u32::<2>(bits) << (lane + 2);
+            mask |= vgetq_lane_u32::<3>(bits) << (lane + 3);
+            lane += 4;
+        }
+    }
+
+    for lane in simd_len..starts.len() {
+        if stops[lane] > query_start && starts[lane] < query_stop {
+            mask |= 1 << lane;
+        }
+    }
+    mask
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline(always)]
+fn overlap_mask(starts: &[u32], stops: &[u32], query_start: u32, query_stop: u32) -> u32 {
+    debug_assert_eq!(starts.len(), stops.len());
+    debug_assert!(starts.len() <= INDEX_BLOCK_SIZE);
+
+    let mut mask = 0_u32;
+    for lane in 0..starts.len() {
+        if stops[lane] > query_start && starts[lane] < query_stop {
+            mask |= 1 << lane;
+        }
+    }
+    mask
+}
+
+impl<'a, T> Iterator for IterFindBlockMask<'a, T>
+where
+    T: Eq + Clone + Send + Sync + 'a,
+{
+    type Item = &'a Interval<u32, T>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.dense_next < self.dense_end {
+                let index = self.dense_next;
+                self.dense_next += 1;
+                return Some(&self.inner.intervals[index]);
+            }
+
+            if self.mask != 0 {
+                let lane = self.mask.trailing_zeros() as usize;
+                self.mask &= self.mask - 1;
+                return Some(&self.inner.intervals[self.mask_block_start + lane]);
+            }
+
+            let block_start = self.next_block_start;
+            if block_start >= self.inner.intervals.len()
+                || self.inner.starts[block_start] >= self.stop
+            {
+                return None;
+            }
+
+            let block = block_start / INDEX_BLOCK_SIZE;
+            if self.inner.block_max_ends[block] <= self.start {
+                self.next_block_start = self.inner.block_index[block] * INDEX_BLOCK_SIZE;
+                continue;
+            }
+
+            let block_end = (block_start + INDEX_BLOCK_SIZE).min(self.inner.intervals.len());
+            if self.inner.block_min_ends[block] > self.start {
+                let starts = &self.inner.starts[block_start..block_end];
+                let active_len = if starts
+                    .last()
+                    .is_some_and(|lane_start| *lane_start < self.stop)
+                {
+                    starts.len()
+                } else {
+                    starts.partition_point(|lane_start| *lane_start < self.stop)
+                };
+                self.dense_next = block_start;
+                self.dense_end = block_start + active_len;
+                self.next_block_start = if active_len == starts.len() {
+                    block_end
+                } else {
+                    self.inner.intervals.len()
+                };
+                continue;
+            }
+
+            self.mask_block_start = block_start;
+            self.next_block_start = block_end;
+            self.mask = overlap_mask(
+                &self.inner.starts[block_start..block_end],
+                &self.inner.stops_by_start[block_start..block_end],
+                self.start,
+                self.stop,
+            );
         }
     }
 }
@@ -729,6 +906,7 @@ where
 {
     inner: &'a Lapper<I, T>,
     off: usize,
+    next_block_start: usize,
     start: I,
     stop: I,
 }
@@ -742,12 +920,14 @@ where
     fn next_blockwise(&mut self) -> Option<&'a Interval<I, T>> {
         while self.off < self.inner.intervals.len() {
             let curr = self.off;
-            if curr.is_multiple_of(INDEX_BLOCK_SIZE) {
+            if curr == self.next_block_start {
                 let block = curr / INDEX_BLOCK_SIZE;
                 if self.inner.block_max_ends[block] <= self.start {
                     self.off = self.inner.block_index[block] * INDEX_BLOCK_SIZE;
+                    self.next_block_start = self.off;
                     continue;
                 }
+                self.next_block_start += INDEX_BLOCK_SIZE;
             }
 
             let interval = &self.inner.intervals[curr];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -868,25 +868,24 @@ where
             }
 
             let block_start = self.next_block_start;
-            if block_start >= self.inner.intervals.len()
-                || self.inner.starts[block_start] >= self.stop
-            {
+            if block_start >= self.inner.intervals.len() {
+                return None;
+            }
+            if unsafe { *self.inner.starts.get_unchecked(block_start) } >= self.stop {
                 return None;
             }
 
             let block = block_start / INDEX_BLOCK_SIZE;
-            if self.inner.block_max_ends[block] <= self.start {
-                self.next_block_start = self.inner.block_index[block] * INDEX_BLOCK_SIZE;
+            if unsafe { *self.inner.block_max_ends.get_unchecked(block) } <= self.start {
+                self.next_block_start =
+                    unsafe { *self.inner.block_index.get_unchecked(block) } * INDEX_BLOCK_SIZE;
                 continue;
             }
 
             let block_end = (block_start + INDEX_BLOCK_SIZE).min(self.inner.intervals.len());
-            if self.inner.block_min_ends[block] > self.start {
-                let starts = &self.inner.starts[block_start..block_end];
-                let active_len = if starts
-                    .last()
-                    .is_some_and(|lane_start| *lane_start < self.stop)
-                {
+            if unsafe { *self.inner.block_min_ends.get_unchecked(block) } > self.start {
+                let starts = unsafe { self.inner.starts.get_unchecked(block_start..block_end) };
+                let active_len = if unsafe { *starts.get_unchecked(starts.len() - 1) } < self.stop {
                     starts.len()
                 } else {
                     starts.partition_point(|lane_start| *lane_start < self.stop)
@@ -904,8 +903,12 @@ where
             self.mask_block_start = block_start;
             self.next_block_start = block_end;
             self.mask = overlap_mask(
-                &self.inner.starts[block_start..block_end],
-                &self.inner.stops_by_start[block_start..block_end],
+                unsafe { self.inner.starts.get_unchecked(block_start..block_end) },
+                unsafe {
+                    self.inner
+                        .stops_by_start
+                        .get_unchecked(block_start..block_end)
+                },
                 self.start,
                 self.stop,
             );

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -124,6 +124,31 @@ fn scalar_mask<I: PrimInt>(starts: &[I], stops: &[I], query_start: I, query_stop
     mask
 }
 
+#[cfg(test)]
+mod dispatch_tests {
+    use super::*;
+
+    #[test]
+    fn selected_backend_matches_the_host() {
+        let backend = detect_backend();
+
+        #[cfg(target_arch = "aarch64")]
+        assert!(matches!(backend, MaskBackend::Neon));
+
+        #[cfg(target_arch = "x86_64")]
+        if std::is_x86_feature_detected!("avx2") {
+            assert!(matches!(backend, MaskBackend::Avx2));
+            eprintln!("runtime backend: AVX2");
+        } else {
+            assert!(matches!(backend, MaskBackend::Scalar));
+            eprintln!("runtime backend: scalar");
+        }
+
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+        assert!(matches!(backend, MaskBackend::Scalar));
+    }
+}
+
 #[cfg(target_arch = "aarch64")]
 mod neon {
     use std::arch::aarch64::*;

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -133,7 +133,10 @@ mod dispatch_tests {
         let backend = detect_backend();
 
         #[cfg(target_arch = "aarch64")]
-        assert!(matches!(backend, MaskBackend::Neon));
+        {
+            assert!(matches!(backend, MaskBackend::Neon));
+            eprintln!("runtime backend: NEON");
+        }
 
         #[cfg(target_arch = "x86_64")]
         if std::is_x86_feature_detected!("avx2") {

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,0 +1,761 @@
+use num_traits::PrimInt;
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+use std::any::TypeId;
+
+pub(crate) const BLOCK_SIZE: usize = 32;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum MaskBackend {
+    Scalar,
+    #[cfg(target_arch = "aarch64")]
+    Neon,
+    #[cfg(target_arch = "x86_64")]
+    Avx2,
+}
+
+#[inline]
+pub(crate) fn detect_backend() -> MaskBackend {
+    #[cfg(target_arch = "aarch64")]
+    {
+        return MaskBackend::Neon;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::is_x86_feature_detected!("avx2") {
+            return MaskBackend::Avx2;
+        }
+    }
+
+    #[allow(unreachable_code)]
+    MaskBackend::Scalar
+}
+
+#[inline(always)]
+pub(crate) fn overlap_mask<I>(
+    backend: MaskBackend,
+    starts: &[I],
+    stops: &[I],
+    query_start: I,
+    query_stop: I,
+) -> u32
+where
+    I: PrimInt + 'static,
+{
+    debug_assert_eq!(starts.len(), stops.len());
+    debug_assert!(starts.len() <= BLOCK_SIZE);
+    let _ = backend;
+
+    #[cfg(target_arch = "aarch64")]
+    if matches!(backend, MaskBackend::Neon) {
+        macro_rules! neon_as {
+            ($source:ty, $repr:ty, $function:path) => {
+                if TypeId::of::<I>() == TypeId::of::<$source>() {
+                    // TypeId proves the source type. On AArch64, usize/isize have the
+                    // same representation and alignment as u64/i64 respectively.
+                    let starts = unsafe {
+                        std::slice::from_raw_parts(starts.as_ptr().cast::<$repr>(), starts.len())
+                    };
+                    let stops = unsafe {
+                        std::slice::from_raw_parts(stops.as_ptr().cast::<$repr>(), stops.len())
+                    };
+                    let query_start = unsafe { *(&query_start as *const I).cast::<$repr>() };
+                    let query_stop = unsafe { *(&query_stop as *const I).cast::<$repr>() };
+                    return unsafe { $function(starts, stops, query_start, query_stop) };
+                }
+            };
+        }
+
+        neon_as!(u8, u8, neon::mask_u8);
+        neon_as!(i8, i8, neon::mask_i8);
+        neon_as!(u16, u16, neon::mask_u16);
+        neon_as!(i16, i16, neon::mask_i16);
+        neon_as!(u32, u32, neon::mask_u32);
+        neon_as!(i32, i32, neon::mask_i32);
+        neon_as!(u64, u64, neon::mask_u64);
+        neon_as!(i64, i64, neon::mask_i64);
+        neon_as!(usize, u64, neon::mask_u64);
+        neon_as!(isize, i64, neon::mask_i64);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if matches!(backend, MaskBackend::Avx2) {
+        macro_rules! avx2_as {
+            ($source:ty, $repr:ty, $function:path) => {
+                if TypeId::of::<I>() == TypeId::of::<$source>() {
+                    // TypeId proves the source type. On x86-64, usize/isize have the
+                    // same representation and alignment as u64/i64 respectively.
+                    let starts = unsafe {
+                        std::slice::from_raw_parts(starts.as_ptr().cast::<$repr>(), starts.len())
+                    };
+                    let stops = unsafe {
+                        std::slice::from_raw_parts(stops.as_ptr().cast::<$repr>(), stops.len())
+                    };
+                    let query_start = unsafe { *(&query_start as *const I).cast::<$repr>() };
+                    let query_stop = unsafe { *(&query_stop as *const I).cast::<$repr>() };
+                    return unsafe { $function(starts, stops, query_start, query_stop) };
+                }
+            };
+        }
+
+        avx2_as!(u8, u8, avx2::mask_u8);
+        avx2_as!(i8, i8, avx2::mask_i8);
+        avx2_as!(u16, u16, avx2::mask_u16);
+        avx2_as!(i16, i16, avx2::mask_i16);
+        avx2_as!(u32, u32, avx2::mask_u32);
+        avx2_as!(i32, i32, avx2::mask_i32);
+        avx2_as!(u64, u64, avx2::mask_u64);
+        avx2_as!(i64, i64, avx2::mask_i64);
+        avx2_as!(usize, u64, avx2::mask_u64);
+        avx2_as!(isize, i64, avx2::mask_i64);
+    }
+
+    scalar_mask(starts, stops, query_start, query_stop)
+}
+
+#[inline(always)]
+fn scalar_mask<I: PrimInt>(starts: &[I], stops: &[I], query_start: I, query_stop: I) -> u32 {
+    let mut mask = 0_u32;
+    for lane in 0..starts.len() {
+        if stops[lane] > query_start && starts[lane] < query_stop {
+            mask |= 1 << lane;
+        }
+    }
+    mask
+}
+
+#[cfg(target_arch = "aarch64")]
+mod neon {
+    use std::arch::aarch64::*;
+
+    #[inline(always)]
+    unsafe fn bits_u8x16(overlap: uint8x16_t) -> u16 {
+        let weights = vld1_u8([1_u8, 2, 4, 8, 16, 32, 64, 128].as_ptr());
+        let low = vaddv_u8(vand_u8(vget_low_u8(overlap), weights));
+        let high = vaddv_u8(vand_u8(vget_high_u8(overlap), weights));
+        u16::from(low) | (u16::from(high) << 8)
+    }
+
+    #[inline(always)]
+    unsafe fn bits_u16x8(overlap: uint16x8_t) -> u8 {
+        let weights = vld1_u8([1_u8, 2, 4, 8, 16, 32, 64, 128].as_ptr());
+        vaddv_u8(vand_u8(vmovn_u16(overlap), weights))
+    }
+
+    #[inline(always)]
+    unsafe fn bits_u16x16(low: uint16x8_t, high: uint16x8_t) -> u16 {
+        bits_u8x16(vcombine_u8(vmovn_u16(low), vmovn_u16(high)))
+    }
+
+    #[inline(always)]
+    unsafe fn bits_u32x4(overlap: uint32x4_t) -> u32 {
+        let weights = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
+        vaddvq_u32(vandq_u32(overlap, weights))
+    }
+
+    #[inline(always)]
+    unsafe fn bits_u32x8(low: uint32x4_t, high: uint32x4_t) -> u16 {
+        let weights = vld1q_u16([1_u16, 2, 4, 8, 16, 32, 64, 128].as_ptr());
+        vaddvq_u16(vandq_u16(
+            vcombine_u16(vmovn_u32(low), vmovn_u32(high)),
+            weights,
+        ))
+    }
+
+    #[inline(always)]
+    unsafe fn bits_u64x4(low: uint64x2_t, high: uint64x2_t) -> u32 {
+        let weights = vld1q_u32([1_u32, 2, 4, 8].as_ptr());
+        vaddvq_u32(vandq_u32(
+            vcombine_u32(vmovn_u64(low), vmovn_u64(high)),
+            weights,
+        ))
+    }
+
+    #[inline(always)]
+    unsafe fn scalar_tail<I: Ord + Copy>(
+        starts: &[I],
+        stops: &[I],
+        query_start: I,
+        query_stop: I,
+        mut lane: usize,
+        mut mask: u32,
+    ) -> u32 {
+        while lane < starts.len() {
+            if *stops.get_unchecked(lane) > query_start && *starts.get_unchecked(lane) < query_stop
+            {
+                mask |= 1 << lane;
+            }
+            lane += 1;
+        }
+        mask
+    }
+
+    pub(super) unsafe fn mask_u8(
+        starts: &[u8],
+        stops: &[u8],
+        query_start: u8,
+        query_stop: u8,
+    ) -> u32 {
+        let query_start_v = vdupq_n_u8(query_start);
+        let query_stop_v = vdupq_n_u8(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 32 <= starts.len() {
+            let lane_starts = vld1q_u8_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u8_x2(stops.as_ptr().add(lane));
+            let low = vandq_u8(
+                vcgtq_u8(lane_stops.0, query_start_v),
+                vcgtq_u8(query_stop_v, lane_starts.0),
+            );
+            let high = vandq_u8(
+                vcgtq_u8(lane_stops.1, query_start_v),
+                vcgtq_u8(query_stop_v, lane_starts.1),
+            );
+            mask |= u32::from(bits_u8x16(low)) << lane;
+            mask |= u32::from(bits_u8x16(high)) << (lane + 16);
+            lane += 32;
+        }
+        while lane + 16 <= starts.len() {
+            let lane_starts = vld1q_u8(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u8(stops.as_ptr().add(lane));
+            let overlap = vandq_u8(
+                vcgtq_u8(lane_stops, query_start_v),
+                vcgtq_u8(query_stop_v, lane_starts),
+            );
+            mask |= u32::from(bits_u8x16(overlap)) << lane;
+            lane += 16;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    pub(super) unsafe fn mask_i8(
+        starts: &[i8],
+        stops: &[i8],
+        query_start: i8,
+        query_stop: i8,
+    ) -> u32 {
+        let query_start_v = vdupq_n_s8(query_start);
+        let query_stop_v = vdupq_n_s8(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 32 <= starts.len() {
+            let lane_starts = vld1q_s8_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_s8_x2(stops.as_ptr().add(lane));
+            let low = vandq_u8(
+                vcgtq_s8(lane_stops.0, query_start_v),
+                vcgtq_s8(query_stop_v, lane_starts.0),
+            );
+            let high = vandq_u8(
+                vcgtq_s8(lane_stops.1, query_start_v),
+                vcgtq_s8(query_stop_v, lane_starts.1),
+            );
+            mask |= u32::from(bits_u8x16(low)) << lane;
+            mask |= u32::from(bits_u8x16(high)) << (lane + 16);
+            lane += 32;
+        }
+        while lane + 16 <= starts.len() {
+            let lane_starts = vld1q_s8(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_s8(stops.as_ptr().add(lane));
+            let overlap = vandq_u8(
+                vcgtq_s8(lane_stops, query_start_v),
+                vcgtq_s8(query_stop_v, lane_starts),
+            );
+            mask |= u32::from(bits_u8x16(overlap)) << lane;
+            lane += 16;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    pub(super) unsafe fn mask_u16(
+        starts: &[u16],
+        stops: &[u16],
+        query_start: u16,
+        query_stop: u16,
+    ) -> u32 {
+        let query_start_v = vdupq_n_u16(query_start);
+        let query_stop_v = vdupq_n_u16(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 16 <= starts.len() {
+            let lane_starts = vld1q_u16_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u16_x2(stops.as_ptr().add(lane));
+            let low = vandq_u16(
+                vcgtq_u16(lane_stops.0, query_start_v),
+                vcgtq_u16(query_stop_v, lane_starts.0),
+            );
+            let high = vandq_u16(
+                vcgtq_u16(lane_stops.1, query_start_v),
+                vcgtq_u16(query_stop_v, lane_starts.1),
+            );
+            mask |= u32::from(bits_u16x16(low, high)) << lane;
+            lane += 16;
+        }
+        while lane + 8 <= starts.len() {
+            let lane_starts = vld1q_u16(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u16(stops.as_ptr().add(lane));
+            let overlap = vandq_u16(
+                vcgtq_u16(lane_stops, query_start_v),
+                vcgtq_u16(query_stop_v, lane_starts),
+            );
+            mask |= u32::from(bits_u16x8(overlap)) << lane;
+            lane += 8;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    pub(super) unsafe fn mask_i16(
+        starts: &[i16],
+        stops: &[i16],
+        query_start: i16,
+        query_stop: i16,
+    ) -> u32 {
+        let query_start_v = vdupq_n_s16(query_start);
+        let query_stop_v = vdupq_n_s16(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 16 <= starts.len() {
+            let lane_starts = vld1q_s16_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_s16_x2(stops.as_ptr().add(lane));
+            let low = vandq_u16(
+                vcgtq_s16(lane_stops.0, query_start_v),
+                vcgtq_s16(query_stop_v, lane_starts.0),
+            );
+            let high = vandq_u16(
+                vcgtq_s16(lane_stops.1, query_start_v),
+                vcgtq_s16(query_stop_v, lane_starts.1),
+            );
+            mask |= u32::from(bits_u16x16(low, high)) << lane;
+            lane += 16;
+        }
+        while lane + 8 <= starts.len() {
+            let lane_starts = vld1q_s16(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_s16(stops.as_ptr().add(lane));
+            let overlap = vandq_u16(
+                vcgtq_s16(lane_stops, query_start_v),
+                vcgtq_s16(query_stop_v, lane_starts),
+            );
+            mask |= u32::from(bits_u16x8(overlap)) << lane;
+            lane += 8;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    pub(super) unsafe fn mask_u32(
+        starts: &[u32],
+        stops: &[u32],
+        query_start: u32,
+        query_stop: u32,
+    ) -> u32 {
+        let query_start_v = vdupq_n_u32(query_start);
+        let query_stop_v = vdupq_n_u32(query_stop);
+        let simd_len = starts.len() / 4 * 4;
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 8 <= simd_len {
+            let lane_starts = vld1q_u32_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u32_x2(stops.as_ptr().add(lane));
+            let low = vandq_u32(
+                vcgtq_u32(lane_stops.0, query_start_v),
+                vcgtq_u32(query_stop_v, lane_starts.0),
+            );
+            let high = vandq_u32(
+                vcgtq_u32(lane_stops.1, query_start_v),
+                vcgtq_u32(query_stop_v, lane_starts.1),
+            );
+            mask |= u32::from(bits_u32x8(low, high)) << lane;
+            lane += 8;
+        }
+        while lane < simd_len {
+            let lane_starts = vld1q_u32(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u32(stops.as_ptr().add(lane));
+            let overlap = vandq_u32(
+                vcgtq_u32(lane_stops, query_start_v),
+                vcgtq_u32(query_stop_v, lane_starts),
+            );
+            mask |= bits_u32x4(overlap) << lane;
+            lane += 4;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    pub(super) unsafe fn mask_i32(
+        starts: &[i32],
+        stops: &[i32],
+        query_start: i32,
+        query_stop: i32,
+    ) -> u32 {
+        let query_start_v = vdupq_n_s32(query_start);
+        let query_stop_v = vdupq_n_s32(query_stop);
+        let simd_len = starts.len() / 4 * 4;
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 8 <= simd_len {
+            let lane_starts = vld1q_s32_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_s32_x2(stops.as_ptr().add(lane));
+            let low = vandq_u32(
+                vcgtq_s32(lane_stops.0, query_start_v),
+                vcgtq_s32(query_stop_v, lane_starts.0),
+            );
+            let high = vandq_u32(
+                vcgtq_s32(lane_stops.1, query_start_v),
+                vcgtq_s32(query_stop_v, lane_starts.1),
+            );
+            mask |= u32::from(bits_u32x8(low, high)) << lane;
+            lane += 8;
+        }
+        while lane < simd_len {
+            let lane_starts = vld1q_s32(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_s32(stops.as_ptr().add(lane));
+            let overlap = vandq_u32(
+                vcgtq_s32(lane_stops, query_start_v),
+                vcgtq_s32(query_stop_v, lane_starts),
+            );
+            mask |= bits_u32x4(overlap) << lane;
+            lane += 4;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    pub(super) unsafe fn mask_u64(
+        starts: &[u64],
+        stops: &[u64],
+        query_start: u64,
+        query_stop: u64,
+    ) -> u32 {
+        let query_start_v = vdupq_n_u64(query_start);
+        let query_stop_v = vdupq_n_u64(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 4 <= starts.len() {
+            let lane_starts = vld1q_u64_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_u64_x2(stops.as_ptr().add(lane));
+            let low = vandq_u64(
+                vcgtq_u64(lane_stops.0, query_start_v),
+                vcgtq_u64(query_stop_v, lane_starts.0),
+            );
+            let high = vandq_u64(
+                vcgtq_u64(lane_stops.1, query_start_v),
+                vcgtq_u64(query_stop_v, lane_starts.1),
+            );
+            mask |= bits_u64x4(low, high) << lane;
+            lane += 4;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    pub(super) unsafe fn mask_i64(
+        starts: &[i64],
+        stops: &[i64],
+        query_start: i64,
+        query_stop: i64,
+    ) -> u32 {
+        let query_start_v = vdupq_n_s64(query_start);
+        let query_stop_v = vdupq_n_s64(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 4 <= starts.len() {
+            let lane_starts = vld1q_s64_x2(starts.as_ptr().add(lane));
+            let lane_stops = vld1q_s64_x2(stops.as_ptr().add(lane));
+            let low = vandq_u64(
+                vcgtq_s64(lane_stops.0, query_start_v),
+                vcgtq_s64(query_stop_v, lane_starts.0),
+            );
+            let high = vandq_u64(
+                vcgtq_s64(lane_stops.1, query_start_v),
+                vcgtq_s64(query_stop_v, lane_starts.1),
+            );
+            mask |= bits_u64x4(low, high) << lane;
+            lane += 4;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+mod avx2 {
+    use std::arch::x86_64::*;
+
+    #[inline(always)]
+    fn compact_u16_movemask(mut bits: u32) -> u32 {
+        bits &= 0x5555_5555;
+        bits = (bits | (bits >> 1)) & 0x3333_3333;
+        bits = (bits | (bits >> 2)) & 0x0f0f_0f0f;
+        bits = (bits | (bits >> 4)) & 0x00ff_00ff;
+        (bits | (bits >> 8)) & 0x0000_ffff
+    }
+
+    #[inline(always)]
+    unsafe fn scalar_tail<I: Ord + Copy>(
+        starts: &[I],
+        stops: &[I],
+        query_start: I,
+        query_stop: I,
+        mut lane: usize,
+        mut mask: u32,
+    ) -> u32 {
+        while lane < starts.len() {
+            if *stops.get_unchecked(lane) > query_start && *starts.get_unchecked(lane) < query_stop
+            {
+                mask |= 1 << lane;
+            }
+            lane += 1;
+        }
+        mask
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn mask_u8(
+        starts: &[u8],
+        stops: &[u8],
+        query_start: u8,
+        query_stop: u8,
+    ) -> u32 {
+        let bias = _mm256_set1_epi8(i8::MIN);
+        let query_start_v = _mm256_xor_si256(_mm256_set1_epi8(query_start as i8), bias);
+        let query_stop_v = _mm256_xor_si256(_mm256_set1_epi8(query_stop as i8), bias);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 32 <= starts.len() {
+            let lane_starts = _mm256_loadu_si256(starts.as_ptr().add(lane).cast());
+            let lane_stops = _mm256_loadu_si256(stops.as_ptr().add(lane).cast());
+            let overlap = _mm256_and_si256(
+                _mm256_cmpgt_epi8(_mm256_xor_si256(lane_stops, bias), query_start_v),
+                _mm256_cmpgt_epi8(query_stop_v, _mm256_xor_si256(lane_starts, bias)),
+            );
+            mask |= (_mm256_movemask_epi8(overlap) as u32) << lane;
+            lane += 32;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn mask_i8(
+        starts: &[i8],
+        stops: &[i8],
+        query_start: i8,
+        query_stop: i8,
+    ) -> u32 {
+        let query_start_v = _mm256_set1_epi8(query_start);
+        let query_stop_v = _mm256_set1_epi8(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 32 <= starts.len() {
+            let lane_starts = _mm256_loadu_si256(starts.as_ptr().add(lane).cast());
+            let lane_stops = _mm256_loadu_si256(stops.as_ptr().add(lane).cast());
+            let overlap = _mm256_and_si256(
+                _mm256_cmpgt_epi8(lane_stops, query_start_v),
+                _mm256_cmpgt_epi8(query_stop_v, lane_starts),
+            );
+            mask |= (_mm256_movemask_epi8(overlap) as u32) << lane;
+            lane += 32;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn mask_u16(
+        starts: &[u16],
+        stops: &[u16],
+        query_start: u16,
+        query_stop: u16,
+    ) -> u32 {
+        let bias = _mm256_set1_epi16(i16::MIN);
+        let query_start_v = _mm256_xor_si256(_mm256_set1_epi16(query_start as i16), bias);
+        let query_stop_v = _mm256_xor_si256(_mm256_set1_epi16(query_stop as i16), bias);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 16 <= starts.len() {
+            let lane_starts = _mm256_loadu_si256(starts.as_ptr().add(lane).cast());
+            let lane_stops = _mm256_loadu_si256(stops.as_ptr().add(lane).cast());
+            let overlap = _mm256_and_si256(
+                _mm256_cmpgt_epi16(_mm256_xor_si256(lane_stops, bias), query_start_v),
+                _mm256_cmpgt_epi16(query_stop_v, _mm256_xor_si256(lane_starts, bias)),
+            );
+            mask |= compact_u16_movemask(_mm256_movemask_epi8(overlap) as u32) << lane;
+            lane += 16;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn mask_i16(
+        starts: &[i16],
+        stops: &[i16],
+        query_start: i16,
+        query_stop: i16,
+    ) -> u32 {
+        let query_start_v = _mm256_set1_epi16(query_start);
+        let query_stop_v = _mm256_set1_epi16(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 16 <= starts.len() {
+            let lane_starts = _mm256_loadu_si256(starts.as_ptr().add(lane).cast());
+            let lane_stops = _mm256_loadu_si256(stops.as_ptr().add(lane).cast());
+            let overlap = _mm256_and_si256(
+                _mm256_cmpgt_epi16(lane_stops, query_start_v),
+                _mm256_cmpgt_epi16(query_stop_v, lane_starts),
+            );
+            mask |= compact_u16_movemask(_mm256_movemask_epi8(overlap) as u32) << lane;
+            lane += 16;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn mask_u32(
+        starts: &[u32],
+        stops: &[u32],
+        query_start: u32,
+        query_stop: u32,
+    ) -> u32 {
+        let bias = _mm256_set1_epi32(i32::MIN);
+        let query_start_v = _mm256_xor_si256(_mm256_set1_epi32(query_start as i32), bias);
+        let query_stop_v = _mm256_xor_si256(_mm256_set1_epi32(query_stop as i32), bias);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 8 <= starts.len() {
+            let lane_starts = _mm256_loadu_si256(starts.as_ptr().add(lane).cast());
+            let lane_stops = _mm256_loadu_si256(stops.as_ptr().add(lane).cast());
+            let overlap = _mm256_and_si256(
+                _mm256_cmpgt_epi32(_mm256_xor_si256(lane_stops, bias), query_start_v),
+                _mm256_cmpgt_epi32(query_stop_v, _mm256_xor_si256(lane_starts, bias)),
+            );
+            mask |= (_mm256_movemask_ps(_mm256_castsi256_ps(overlap)) as u32) << lane;
+            lane += 8;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn mask_i32(
+        starts: &[i32],
+        stops: &[i32],
+        query_start: i32,
+        query_stop: i32,
+    ) -> u32 {
+        let query_start_v = _mm256_set1_epi32(query_start);
+        let query_stop_v = _mm256_set1_epi32(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 8 <= starts.len() {
+            let lane_starts = _mm256_loadu_si256(starts.as_ptr().add(lane).cast());
+            let lane_stops = _mm256_loadu_si256(stops.as_ptr().add(lane).cast());
+            let overlap = _mm256_and_si256(
+                _mm256_cmpgt_epi32(lane_stops, query_start_v),
+                _mm256_cmpgt_epi32(query_stop_v, lane_starts),
+            );
+            mask |= (_mm256_movemask_ps(_mm256_castsi256_ps(overlap)) as u32) << lane;
+            lane += 8;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn mask_u64(
+        starts: &[u64],
+        stops: &[u64],
+        query_start: u64,
+        query_stop: u64,
+    ) -> u32 {
+        let bias = _mm256_set1_epi64x(i64::MIN);
+        let query_start_v = _mm256_xor_si256(_mm256_set1_epi64x(query_start as i64), bias);
+        let query_stop_v = _mm256_xor_si256(_mm256_set1_epi64x(query_stop as i64), bias);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 4 <= starts.len() {
+            let lane_starts = _mm256_loadu_si256(starts.as_ptr().add(lane).cast());
+            let lane_stops = _mm256_loadu_si256(stops.as_ptr().add(lane).cast());
+            let overlap = _mm256_and_si256(
+                _mm256_cmpgt_epi64(_mm256_xor_si256(lane_stops, bias), query_start_v),
+                _mm256_cmpgt_epi64(query_stop_v, _mm256_xor_si256(lane_starts, bias)),
+            );
+            mask |= (_mm256_movemask_pd(_mm256_castsi256_pd(overlap)) as u32) << lane;
+            lane += 4;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn mask_i64(
+        starts: &[i64],
+        stops: &[i64],
+        query_start: i64,
+        query_stop: i64,
+    ) -> u32 {
+        let query_start_v = _mm256_set1_epi64x(query_start);
+        let query_stop_v = _mm256_set1_epi64x(query_stop);
+        let mut lane = 0;
+        let mut mask = 0;
+        while lane + 4 <= starts.len() {
+            let lane_starts = _mm256_loadu_si256(starts.as_ptr().add(lane).cast());
+            let lane_stops = _mm256_loadu_si256(stops.as_ptr().add(lane).cast());
+            let overlap = _mm256_and_si256(
+                _mm256_cmpgt_epi64(lane_stops, query_start_v),
+                _mm256_cmpgt_epi64(query_stop_v, lane_starts),
+            );
+            mask |= (_mm256_movemask_pd(_mm256_castsi256_pd(overlap)) as u32) << lane;
+            lane += 4;
+        }
+        scalar_tail(starts, stops, query_start, query_stop, lane, mask)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn u16_movemask_compaction_preserves_every_lane_bit() {
+            for expected in 0_u32..=u16::MAX.into() {
+                let mut expanded = 0_u32;
+                for lane in 0..16 {
+                    if expected & (1 << lane) != 0 {
+                        expanded |= 0b11 << (lane * 2);
+                    }
+                }
+                assert_eq!(compact_u16_movemask(expanded), expected);
+            }
+        }
+
+        #[test]
+        fn primitive_masks_match_scalar_when_avx2_is_available() {
+            if !std::is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            macro_rules! check_unsigned {
+                ($type:ty, $function:path) => {{
+                    let starts: Vec<$type> = (0..32).map(|lane| (lane * 4) as $type).collect();
+                    let stops: Vec<$type> = starts.iter().map(|start| *start + 20).collect();
+                    let expected =
+                        super::super::scalar_mask(&starts, &stops, 37 as $type, 91 as $type);
+                    assert_eq!(
+                        unsafe { $function(&starts, &stops, 37 as $type, 91 as $type) },
+                        expected
+                    );
+                }};
+            }
+
+            macro_rules! check_signed {
+                ($type:ty, $function:path) => {{
+                    let starts: Vec<$type> = (0..32).map(|lane| (lane * 4 - 64) as $type).collect();
+                    let stops: Vec<$type> = starts.iter().map(|start| *start + 20).collect();
+                    let expected =
+                        super::super::scalar_mask(&starts, &stops, -11 as $type, 43 as $type);
+                    assert_eq!(
+                        unsafe { $function(&starts, &stops, -11 as $type, 43 as $type) },
+                        expected
+                    );
+                }};
+            }
+
+            check_unsigned!(u8, mask_u8);
+            check_unsigned!(u16, mask_u16);
+            check_unsigned!(u32, mask_u32);
+            check_unsigned!(u64, mask_u64);
+            check_signed!(i8, mask_i8);
+            check_signed!(i16, mask_i16);
+            check_signed!(i32, mask_i32);
+            check_signed!(i64, mask_i64);
+        }
+    }
+}

--- a/tests/block_index.rs
+++ b/tests/block_index.rs
@@ -1,0 +1,40 @@
+use rust_lapper::{Interval, Lapper};
+
+#[test]
+fn block_index_matches_forward_brute_force() {
+    let mut state = 0x1234_5678_u64;
+    let mut next = || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (state >> 32) as u32
+    };
+
+    let mut intervals = Vec::new();
+    intervals.push(Interval {
+        start: 0,
+        stop: 1_000_000,
+        val: 0usize,
+    });
+    for value in 1..5000 {
+        let start = next() % 1_000_000;
+        let len = 1 + next() % 1000;
+        intervals.push(Interval {
+            start,
+            stop: start + len,
+            val: value,
+        });
+    }
+    let lapper = Lapper::new(intervals);
+
+    for _ in 0..20_000 {
+        let start = next() % 1_000_000;
+        let stop = start + 1 + next() % 2000;
+        let got: Vec<_> = lapper.find(start, stop).map(|iv| iv.val).collect();
+        let expected: Vec<_> = lapper
+            .intervals
+            .iter()
+            .filter(|iv| iv.start < stop && iv.stop > start)
+            .map(|iv| iv.val)
+            .collect();
+        assert_eq!(got, expected, "query {start}..{stop}");
+    }
+}

--- a/tests/block_index.rs
+++ b/tests/block_index.rs
@@ -29,10 +29,6 @@ fn block_index_matches_forward_brute_force() {
         let start = next() % 1_000_000;
         let stop = start + 1 + next() % 2000;
         let got: Vec<_> = lapper.find(start, stop).map(|iv| iv.val).collect();
-        let got_mask: Vec<_> = lapper
-            .find_block_mask(start, stop)
-            .map(|iv| iv.val)
-            .collect();
         let expected: Vec<_> = lapper
             .intervals
             .iter()
@@ -40,6 +36,5 @@ fn block_index_matches_forward_brute_force() {
             .map(|iv| iv.val)
             .collect();
         assert_eq!(got, expected, "query {start}..{stop}");
-        assert_eq!(got_mask, expected, "block mask query {start}..{stop}");
     }
 }

--- a/tests/block_index.rs
+++ b/tests/block_index.rs
@@ -29,6 +29,10 @@ fn block_index_matches_forward_brute_force() {
         let start = next() % 1_000_000;
         let stop = start + 1 + next() % 2000;
         let got: Vec<_> = lapper.find(start, stop).map(|iv| iv.val).collect();
+        let got_mask: Vec<_> = lapper
+            .find_block_mask(start, stop)
+            .map(|iv| iv.val)
+            .collect();
         let expected: Vec<_> = lapper
             .intervals
             .iter()
@@ -36,5 +40,6 @@ fn block_index_matches_forward_brute_force() {
             .map(|iv| iv.val)
             .collect();
         assert_eq!(got, expected, "query {start}..{stop}");
+        assert_eq!(got_mask, expected, "block mask query {start}..{stop}");
     }
 }

--- a/tests/portable_index.rs
+++ b/tests/portable_index.rs
@@ -1,0 +1,177 @@
+use num_traits::PrimInt;
+use rust_lapper::{Interval, Lapper};
+
+fn assert_queries_match<I>(lapper: &Lapper<I, usize>, query_min: i64, query_max: i64)
+where
+    I: PrimInt + Ord + Clone + Send + Sync + 'static,
+{
+    let mut cursor = 0;
+    for raw_start in query_min..query_max {
+        let start = I::from(raw_start).unwrap();
+        let stop = I::from(raw_start + 7).unwrap();
+        let expected: Vec<_> = lapper
+            .intervals
+            .iter()
+            .filter(|interval| interval.start < stop && interval.stop > start)
+            .map(|interval| interval.val)
+            .collect();
+        let found: Vec<_> = lapper
+            .find(start, stop)
+            .map(|interval| interval.val)
+            .collect();
+        let sought: Vec<_> = lapper
+            .seek(start, stop, &mut cursor)
+            .map(|interval| interval.val)
+            .collect();
+        assert_eq!(found, expected, "find query {raw_start}..{}", raw_start + 7);
+        assert_eq!(
+            sought,
+            expected,
+            "seek query {raw_start}..{}",
+            raw_start + 7
+        );
+        assert_eq!(
+            lapper.count(start, stop),
+            expected.len(),
+            "count query {raw_start}..{}",
+            raw_start + 7
+        );
+    }
+}
+
+fn exercise_unsigned<I>()
+where
+    I: PrimInt + Ord + Clone + Send + Sync + 'static,
+{
+    let intervals = (0..96)
+        .map(|value| {
+            let raw_start = (value * 2) % 181;
+            let raw_stop = raw_start + 1 + (value * 7) % 19;
+            Interval {
+                start: I::from(raw_start).unwrap(),
+                stop: I::from(raw_stop).unwrap(),
+                val: value,
+            }
+        })
+        .collect();
+    assert_queries_match(&Lapper::new(intervals), 0, 190);
+}
+
+fn exercise_signed<I>()
+where
+    I: PrimInt + Ord + Clone + Send + Sync + 'static,
+{
+    let intervals = (0..96)
+        .map(|value| {
+            let raw_start = (value * 2) as i64 % 121 - 60;
+            let raw_stop = raw_start + 1 + (value * 7) as i64 % 19;
+            Interval {
+                start: I::from(raw_start).unwrap(),
+                stop: I::from(raw_stop).unwrap(),
+                val: value,
+            }
+        })
+        .collect();
+    assert_queries_match(&Lapper::new(intervals), -70, 70);
+}
+
+#[test]
+fn every_primitive_integer_type_matches_forward_brute_force() {
+    exercise_unsigned::<u8>();
+    exercise_unsigned::<u16>();
+    exercise_unsigned::<u32>();
+    exercise_unsigned::<u64>();
+    exercise_unsigned::<usize>();
+    exercise_signed::<i8>();
+    exercise_signed::<i16>();
+    exercise_signed::<i32>();
+    exercise_signed::<i64>();
+    exercise_signed::<isize>();
+}
+
+#[test]
+fn insert_rebuilds_every_query_index() {
+    let mut lapper = Lapper::<u32, usize>::new(Vec::new());
+    for value in (0..129).rev() {
+        let start = (value * 13 % 257) as u32;
+        lapper.insert(Interval {
+            start,
+            stop: start + 1 + (value * 11 % 31) as u32,
+            val: value,
+        });
+    }
+    assert_queries_match(&lapper, 0, 280);
+}
+
+#[test]
+fn merge_rebuilds_every_query_index() {
+    let intervals = (0..160)
+        .map(|value| {
+            let start = (value * 3) as u32;
+            Interval {
+                start,
+                stop: start + 5 + (value % 9) as u32,
+                val: value,
+            }
+        })
+        .collect();
+    let mut lapper = Lapper::new(intervals);
+    lapper.merge_overlaps();
+    assert_queries_match(&lapper, 0, 500);
+}
+
+#[test]
+fn signed_seek_saturates_at_the_coordinate_minimum() {
+    let lapper = Lapper::new(vec![
+        Interval {
+            start: i8::MIN,
+            stop: -100,
+            val: 0_usize,
+        },
+        Interval {
+            start: -110,
+            stop: -90,
+            val: 1,
+        },
+    ]);
+    let mut cursor = 0;
+    let found: Vec<_> = lapper
+        .seek(-125, -105, &mut cursor)
+        .map(|interval| interval.val)
+        .collect();
+    assert_eq!(found, vec![0, 1]);
+}
+
+#[test]
+fn signed_depth_crosses_zero_once() {
+    let lapper = Lapper::new(vec![Interval {
+        start: -2_i16,
+        stop: 3,
+        val: (),
+    }]);
+    let depth: Vec<_> = lapper.depth().collect();
+    assert_eq!(
+        depth,
+        vec![Interval {
+            start: -2,
+            stop: 3,
+            val: 1
+        }]
+    );
+}
+
+#[test]
+fn direct_structural_growth_cannot_extend_unchecked_indexing() {
+    let mut lapper = Lapper::new(vec![Interval {
+        start: 1_u32,
+        stop: 3,
+        val: 0_usize,
+    }]);
+    lapper.intervals.push(Interval {
+        start: 4,
+        stop: 6,
+        val: 1,
+    });
+    let found: Vec<_> = lapper.find(0, 10).map(|interval| interval.val).collect();
+    assert_eq!(found, vec![0]);
+}

--- a/tests/portable_index.rs
+++ b/tests/portable_index.rs
@@ -81,11 +81,13 @@ fn every_primitive_integer_type_matches_forward_brute_force() {
     exercise_unsigned::<u16>();
     exercise_unsigned::<u32>();
     exercise_unsigned::<u64>();
+    exercise_unsigned::<u128>();
     exercise_unsigned::<usize>();
     exercise_signed::<i8>();
     exercise_signed::<i16>();
     exercise_signed::<i32>();
     exercise_signed::<i64>();
+    exercise_signed::<i128>();
     exercise_signed::<isize>();
 }
 


### PR DESCRIPTION
## A Note On AI 🤖 

I used agents extensively to benchmark different possible implementations and try out different indexing methods etc. The two key ideas were, surprisingly, my own, using the block-based index and inter-block simd comparisons. 

I'm still conflicted about having agents do any of this, as this is not a library that has been touched by AI previously, and I don't know how dependents on this lib feel about agentically written code. If you have strong feelings and read this, open an issue and lets discuss it.

## Summary

This replaces the original `max_len`-bounded forward scan with an always-on
32-interval block index while preserving rust-lapper's existing borrowed,
start-ordered iterator identity.

Blocks that are certainly before a query are skipped using exact maximum-end
summaries and forward next-greater links. Dense active prefixes are returned
directly, while mixed blocks are classified with an exact 32-bit overlap mask.
The mask backend uses AArch64 NEON, runtime-dispatched x86-64 AVX2, or an exact
scalar fallback.

## Compatibility

- The public query API and forward result order remain unchanged.
- All primitive signed and unsigned coordinate types use specialized SIMD
  kernels where supported.
- Custom `PrimInt` implementations use the scalar mask.
- Constructors, insertion, merging, and deserialization rebuild the derived
  index.
- Serde retains the original six-field representation.
- There is no workload heuristic or user-visible mode.

The branch adds an `I: 'static` bound for safe `TypeId`-based primitive
dispatch. Stable Rust cannot specialize primitive SIMD kernels while retaining
a blanket custom-`PrimInt` fallback, so the bound is accepted and documented.
It excludes lifetime-carrying coordinate types, not short-lived `Lapper`
values.

## Performance

Apple M3/AArch64 medians versus rust-lapper 1.3.0:

| Dataset | Original total | This branch total | Speedup |
|---|---:|---:|---:|
| `1-2` | 8.534 ms | 5.729 ms | 1.49x |
| `7-3` | 5,075.695 ms | 66.385 ms | 76.46x |
| `8-7` | 920.998 ms | 588.766 ms | 1.56x |

All implementations returned identical overlap counts. Baseline and final
values came from separate controlled runs, so they are orientation numbers
rather than paired percentage estimates.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- AArch64 assembly inspection and native comparative benchmarks
- Native AArch64 NEON execution on Apple and GitHub ARM64 runners
- Native AVX2 execution and primitive-mask verification on an AMD EPYC 7763
- x86-64 scalar dispatch and full tests under a QEMU Nehalem CPU model
- Rust 1.59 MSRV and current-stable all-feature tests
- Default, serde-only, unstable-sort-only, and all-feature configurations
- i686, PowerPC64LE, and Wasm scalar-fallback compilation

Native Intel/AMD AVX2 performance validation remains outstanding.

## Production gates

The exact five-gate checklist is recorded in `plans/productionization.md`:

1. **In progress:** AVX2 correctness is native; native x86 performance and a
   physical non-AVX2 host remain.
2. **Complete:** the declared MSRV is Rust 1.59.
3. **Complete:** the documented `I: 'static` bound is accepted.
4. **Complete:** construction-time cached dispatch regressed all three
   workloads and was rejected.
5. **Complete:** the expanded final CI matrix is green.
